### PR TITLE
add handling in bdd runner for unstable operations

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -281,7 +281,7 @@ def api(package_name, client, name):
 
 @given(parsers.parse('operation "{name}" enabled'))
 def operation_enabled(client, name):
-    """Return an API instance."""
+    """Enable the unstable operation specific in the clause."""
     client.configuration.unstable_operations[snake_case(name)] = True
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -279,6 +279,11 @@ def api(package_name, client, name):
         "calls": [],
     }
 
+@given(parsers.parse('operation "{name}" enabled'))
+def operation_enabled(client, name):
+    """Return an API instance."""
+    client.configuration.unstable_operations[snake_case(name)] = True
+
 
 @given(parsers.parse('new "{name}" request'))
 def api_request(api, name):


### PR DESCRIPTION
### What does this PR do?
- adds a handling for BDD "given" clauses that enable unstable operations
  - this is necessary to support BDD testing for unstable endpoints being added for incident management

### Additional Notes

### Review checklist
Please check relevant items below:
- [x] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.


- [x] This PR does not rely on API client schema changes.
    - [x] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
