### PR TITLE
Add job for uploading the package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Build
+
+on:
+  pull_request:
+  release:
+    types:
+      - published
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ubuntu-16.04
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/checkout@v2
+        # Include all history and tags, needed for building the right version
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.8'
+
+      - name: Install datadog_checks_dev
+        run: |
+          python -m pip install datadog_checks_dev[cli]
+
+      - name: Set ddev pypi credentials
+        run: |
+          ddev config set pypi.user __token__
+          ddev config set pypi.token ${{ secrets.PYPI_TOKEN }}
+
+      - name: Build the wheel
+        run: |
+          ddev release build .
+
+      - name: Publish the wheel to PyPI
+        run: |
+          ddev release upload .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,6 @@ jobs:
           ddev config set pypi.user __token__
           ddev config set pypi.token ${{ secrets.PYPI_TOKEN }}
 
-      - name: Build the wheel
-        run: |
-          ddev release build .
-
       - name: Publish the wheel to PyPI
         run: |
           ddev release upload .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Adds a github action workflow for creating and uploading a package to pypi. This essentially translates the same RELEASING.md file we use now as a github action. 

The release workflow will be to create a "release" on github, and have this automatically triggered to build and push the packaged wheel to pypi. 

Once this is tested with one release, I can update the RELEASE.md file