### PR TITLE
Set ddev config pypi pass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set ddev pypi credentials
         run: |
           ddev config set pypi.user __token__
-          ddev config set pypi.token ${{ secrets.PYPI_TOKEN }}
+          ddev config set pypi.pass ${{ secrets.PYPI_TOKEN }}
 
       - name: Publish the wheel to PyPI
         run: |


### PR DESCRIPTION
ddev expects the config to look like:

[pypi]
user = <username>
pass = <password>

Source - https://github.com/DataDog/integrations-core/blob/master/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/upload.py#L35

I previously set this as `token` instead of `pass`