### PR TITLE
Update release instructions

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,27 +7,21 @@ This project does not have a strict release schedule. However, we would make a r
   - No release will be done if no changes got merged to the `master` branch during the above mentioned window.
   - Releases may be done more frequently than the above mentioned window.
 
-## Make Sure Everything Works
-* Make sure tests are passing.
-  - Locally and in the continuous integration system.
-* Make sure documentation is up-to-date and building correctly.
-* Build the package locally (e.g. `python3 setup.py sdist`), install it into a fresh virtualenv and test the changes that have been made since the last release.
-
 ## Release Process
 Our team will trigger the release pipeline.
 
 ### Prerequisite 
 - Install [datadog_checks_dev](https://datadog-checks-base.readthedocs.io/en/latest/datadog_checks_dev.cli.html#installation) using Python 3.
-- Setup PyPI, see the internal documentation for more details
 
 ### Update Changelog
 #### Commands
 - See changes ready for release by running `ddev release show changes .` at the root of this project. Add any missing labels to PRs if needed.
 - Run `ddev release changelog . <NEW_VERSION>` to update the `CHANGELOG.md` file at the root of this repository
-- Commit the changes to the repository in a release branch and open a PR. Do not merge yet.
+- Commit the changes to the repository in a release branch and open a PR.
+    - Ensure CI passes fully here, this is the commit that will be released!
+    - Ensure the [documentation builds](https://readthedocs.org/projects/datadog-api-client/builds/) are passing
+    - Get this PR approved and merged
 
 ### Release
 1. Create the release on GitHub. [Example](https://github.com/DataDog/datadog-api-client-python/releases/tag/1.0.0b1)
-1. Checkout the tag created at the previous step.
-1. Run `ddev release build .` and `ddev release upload . `.
-   - Make sure that both an `sdist` and a [universal wheel](https://packaging.python.org/guides/distributing-packages-using-setuptools/#universal-wheels) have been uploaded to [PyPI](https://pypi.python.org/pypi/datadog/).
+1. A github action will kick off that builds and publishes this tag to PyPI. Confirm the [release is available](https://pypi.org/project/datadog-api-client/#history)


### PR DESCRIPTION
Update the release instructions to reflect the latest process used when releasing beta.2

* Remove the "make sure everything works section". Instead lets ensure specifically that the CI is passing on the Changelog PR, as this is the final commit that will get released to users. 
* Remove setting up PyPI from the instructions since the new github action will take care of this
* Add readthedocs builds link to show where to look to make sure docs builds are passing