### PR TITLE
Store unknown model properties in `_data_store` map

### DIFF
--- a/.generator/templates/model_utils.mustache
+++ b/.generator/templates/model_utils.mustache
@@ -494,7 +494,8 @@ class ModelNormal(OpenApiModel):
                         self._configuration is not None and \
                         self._configuration.discard_unknown_keys and \
                         self.additional_properties_type is None:
-                # discard variable.
+                # If it's returned from the API, store it if we need to send it back
+                self.__dict__["_data_store"][var_name] = var_value
                 continue
             setattr(self, var_name, var_value)
         return self

--- a/src/datadog_api_client/v1/model_utils.py
+++ b/src/datadog_api_client/v1/model_utils.py
@@ -630,7 +630,8 @@ class ModelNormal(OpenApiModel):
                 and self._configuration.discard_unknown_keys
                 and self.additional_properties_type is None
             ):
-                # discard variable.
+                # If it's returned from the API, store it if we need to send it back
+                self.__dict__["_data_store"][var_name] = var_value
                 continue
             setattr(self, var_name, var_value)
         return self

--- a/src/datadog_api_client/v2/model_utils.py
+++ b/src/datadog_api_client/v2/model_utils.py
@@ -630,7 +630,8 @@ class ModelNormal(OpenApiModel):
                 and self._configuration.discard_unknown_keys
                 and self.additional_properties_type is None
             ):
-                # discard variable.
+                # If it's returned from the API, store it if we need to send it back
+                self.__dict__["_data_store"][var_name] = var_value
                 continue
             setattr(self, var_name, var_value)
         return self

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -8,7 +8,11 @@ from datadog_api_client.v1 import Configuration as Configuration
 from datadog_api_client.v2.model.logs_aggregate_response import LogsAggregateResponse
 from datadog_api_client.v2.model.logs_archive import LogsArchive
 from datadog_api_client.v2.model.logs_archive_destination import LogsArchiveDestination
-from datadog_api_client.v2.model_utils import validate_and_convert_types as validate_and_convert_types_v2
+from datadog_api_client.v2.model.user_response import UserResponse
+from datadog_api_client.v2.model_utils import (
+    validate_and_convert_types as validate_and_convert_types_v2,
+    model_to_dict as model_to_dict_v2,
+)
 from datadog_api_client.v2 import Configuration as ConfigurationV2
 
 
@@ -283,3 +287,37 @@ def test_one_of_primitive_types():
     )
     assert isinstance(deserialized_data, LogsAggregateResponse)
     assert deserialized_data.data.buckets[0].computes["c0"] == 435.3
+
+
+def test_unknown_model_value():
+    body = """{
+        "data": {
+            "type": "users",
+            "id": "6d716162-8b48-11ec-8120-da7ad0900002",
+            "attributes": {
+                "name": null,
+                "created_at": "2022-02-11T14:39:33.168622+00:00",
+                "modified_at": "2022-02-11T14:39:33.210204+00:00",
+                "title": "user title",
+                "verified": false,
+                "service_account": false,
+                "disabled": false,
+                "allowed_login_methods": [],
+                "status": "Pending"
+            },
+            "relationships": {
+                "roles": { "data": [] },
+                "org": {
+                    "data": { "type": "orgs", "id": "4dee724d-00cc-11ea-a77b-570c9d03c6c5" }
+                }
+            }
+        }
+    }"""
+    config = ConfigurationV2()
+    deserialized_data = validate_and_convert_types_v2(
+        json.loads(body), (UserResponse,), ["received_data"], True, True, config
+    )
+    assert isinstance(deserialized_data, UserResponse)
+    serialized = model_to_dict_v2(deserialized_data)
+    assert "allowed_login_methods" in serialized["data"]["attributes"]
+    assert serialized["data"]["attributes"]["allowed_login_methods"] == []


### PR DESCRIPTION
The discarding when coming from the API is not very useful, let's try to
store raw data.