### PR TITLE
Publish sdist

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,15 +21,14 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install datadog_checks_dev
-        run: |
-          python -m pip install datadog_checks_dev[cli]
+      - name: Install pypa/build
+        run: python -m pip install build --user
 
-      - name: Set ddev pypi credentials
-        run: |
-          ddev config set pypi.user __token__
-          ddev config set pypi.pass ${{ secrets.PYPI_TOKEN }}
+      - name: Build a binary wheel and a source tarball
+        run: python -m build --sdist --wheel --outdir dist/ .
 
-      - name: Publish the wheel to PyPI
-        run: |
-          ddev release upload .
+      - name: Publish a Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
### What does this PR do?

Adds `sdist` target.

See also https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/

Closes #858 