### PR TITLE
Use standalone binary for `datadog-ci` instead of `npm`

### DIFF
--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -49,12 +49,11 @@ jobs:
           repo: datadog-api-spec
           status: pending
           context: integration
-      - name: Set up Node 14
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14
       - name: Report source code metadata
-        run: npx @datadog/datadog-ci git-metadata upload
+        run: |
+          curl -L "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci-linux-x64" --output ./datadog-ci
+          chmod +x "./datadog-ci"
+          ./datadog-ci git-metadata upload
         env:
           DATADOG_API_KEY: ${{ secrets.DD_API_KEY }}
       - name: Set up Python 3.10


### PR DESCRIPTION
### What does this PR do?

Make it simpler to use `datadog-ci`: use new standalone binary instead of setting up node and installing `datadog-ci` with `npm`

### Review checklist

Please check relevant items below:

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [x] This PR does not rely on API client schema changes.
  - [x] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.
