### PR TITLE
Bump minimum python

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,15 +58,15 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ["3.6", "3.10"]
+        python-version: ["3.7", "3.10"]
         platform: [ubuntu-latest, macos-latest] # windows-latest
         # test only latest version on macos and windows
         exclude:
           - platform: macos-latest
-            python-version: "3.6"
+            python-version: "3.7"
           # TODO enable once dd-trace-py is updated
           # - platform: windows-latest
-          #  python-version: 3.6
+          #  python-version: 3.7
           # - platform: windows-latest
           #   python-version: 3.7
     runs-on: ${{ matrix.platform }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ classifiers=
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -38,7 +37,7 @@ packages = find:
 package_dir=
     =src
 include_package_data = True
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     urllib3>=1.15
     six>=1.10


### PR DESCRIPTION
3.6 is EOL, let's make 3.7 the minimum.