### PR TITLE
Remove a few other doc warnings

### DIFF
--- a/.generator/src/generator/formatter.py
+++ b/.generator/src/generator/formatter.py
@@ -60,14 +60,14 @@ def attribute_path(attribute):
 class CustomRenderer(m2r2.RestRenderer):
     def double_emphasis(self, text):
         if "``" in text:
-            text = text.replace("\ ``", "").replace("``\ ", "")
+            text = text.replace("\\ ``", "").replace("``\\ ", "")
         if "`_" in text:
             return text
-        return super().double_emphasis(text)
+        return "\\ **{}**\\ ".format(text)
 
     def header(self, text, level, raw=None):
         return "\n{}\n".format(self.double_emphasis(text))
 
 
 def docstring(text):
-    return m2r2.convert(text.replace("\\n", "\\\\n"), renderer=CustomRenderer())[1:-1]
+    return m2r2.convert(text.replace("\\n", "\\\\n"), renderer=CustomRenderer())[1:-1].replace("\\ ", " ")

--- a/.generator/src/generator/formatter.py
+++ b/.generator/src/generator/formatter.py
@@ -61,6 +61,8 @@ class CustomRenderer(m2r2.RestRenderer):
     def double_emphasis(self, text):
         if "``" in text:
             text = text.replace("\ ``", "").replace("``\ ", "")
+        if "`_" in text:
+            return text
         return super().double_emphasis(text)
 
     def header(self, text, level, raw=None):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,8 +4,11 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+import difflib
 import os
 import sys
+
+from sphinx.domains.python import PythonDomain
 
 sys.path.insert(0, os.path.abspath("../src"))
 
@@ -73,3 +76,62 @@ html_theme_options = {
 add_module_names = False
 
 autoclass_content = "both"
+
+
+def find_obj(domain, env, modname, classname, name, type, searchmode=0):
+    # skip parens
+    if name[-2:] == '()':
+        name = name[:-2]
+
+    if not name:
+        return []
+
+    matches = []
+
+    newname = None
+    if searchmode == 1:
+        if type is None:
+            objtypes = list(domain.object_types)
+        else:
+            objtypes = domain.objtypes_for_role(type)
+        if objtypes is not None:
+            if modname and classname:
+                fullname = modname + '.' + classname + '.' + name
+                if fullname in domain.objects and domain.objects[fullname].objtype in objtypes:
+                    newname = fullname
+            if not newname:
+                if modname and modname + '.' + name in domain.objects and \
+                   domain.objects[modname + '.' + name].objtype in objtypes:
+                    newname = modname + '.' + name
+                elif name in domain.objects and domain.objects[name].objtype in objtypes:
+                    newname = name
+                else:
+                    # "fuzzy" searching mode
+                    searchname = '.' + name
+                    matches = [(oname, domain.objects[oname]) for oname in domain.objects
+                               if oname.endswith(searchname) and
+                               domain.objects[oname].objtype in objtypes]
+                    if len(matches) > 1:
+                        close_match = difflib.get_close_matches(modname, [m[0] for m in matches], n=1, cutoff=0.1)
+                        if close_match:
+                            matches = [m for m in matches if m[0] == close_match[0]]
+    else:
+        # NOTE: searching for exact match, object type is not considered
+        if name in domain.objects:
+            newname = name
+        elif type == 'mod':
+            # only exact matches allowed for modules
+            return []
+        elif classname and classname + '.' + name in domain.objects:
+            newname = classname + '.' + name
+        elif modname and modname + '.' + name in domain.objects:
+            newname = modname + '.' + name
+        elif modname and classname and \
+                modname + '.' + classname + '.' + name in domain.objects:
+            newname = modname + '.' + classname + '.' + name
+    if newname is not None:
+        matches.append((newname, domain.objects[newname]))
+    return matches
+
+
+PythonDomain.find_obj = find_obj

--- a/src/datadog_api_client/v1/api/aws_integration_api.py
+++ b/src/datadog_api_client/v1/api/aws_integration_api.py
@@ -300,8 +300,8 @@ class AWSIntegrationApi:
         >>> thread = api.create_aws_tag_filter(body, async_req=True)
         >>> result = thread.get()
 
-        :param body: Set an AWS tag filter using an ``aws_account_identifier``\ , ``namespace``\ , and filtering string.
-            Namespace options are ``application_elb``\ , ``elb``\ , ``lambda``\ , ``network_elb``\ , ``rds``\ , ``sqs``\ , and ``custom``.
+        :param body: Set an AWS tag filter using an ``aws_account_identifier`` , ``namespace`` , and filtering string.
+            Namespace options are ``application_elb`` , ``elb`` , ``lambda`` , ``network_elb`` , ``rds`` , ``sqs`` , and ``custom``.
         :type body: AWSTagFilterCreateRequest
         :param _return_http_data_only: Response data without head status
             code and headers. Default is True.

--- a/src/datadog_api_client/v1/api/azure_integration_api.py
+++ b/src/datadog_api_client/v1/api/azure_integration_api.py
@@ -303,7 +303,7 @@ class AzureIntegrationApi:
         """Update an Azure integration.
 
         Update a Datadog-Azure integration. Requires an existing ``tenant_name`` and ``client_id``.
-        Any other fields supplied will overwrite existing values. To overwrite ``tenant_name`` or ``client_id``\ ,
+        Any other fields supplied will overwrite existing values. To overwrite ``tenant_name`` or ``client_id`` ,
         use ``new_tenant_name`` and ``new_client_id``. To leave a field unchanged, do not supply that field in the payload.
 
         This method makes a synchronous HTTP request by default. To make an

--- a/src/datadog_api_client/v1/api/dashboards_api.py
+++ b/src/datadog_api_client/v1/api/dashboards_api.py
@@ -373,7 +373,7 @@ class DashboardsApi:
 
         Get all dashboards.
 
-        **Note**\ : This query will only return custom created or cloned dashboards.
+        **Note** : This query will only return custom created or cloned dashboards.
         This query will not return preset dashboards.
 
         This method makes a synchronous HTTP request by default. To make an
@@ -382,10 +382,10 @@ class DashboardsApi:
         >>> thread = api.list_dashboards(async_req=True)
         >>> result = thread.get()
 
-        :param filter_shared: When ``true``\ , this query only returns shared custom created
+        :param filter_shared: When ``true`` , this query only returns shared custom created
             or cloned dashboards.
         :type filter_shared: bool, optional
-        :param filter_deleted: When ``true``\ , this query returns only deleted custom-created
+        :param filter_deleted: When ``true`` , this query returns only deleted custom-created
             or cloned dashboards. This parameter is incompatible with ``filter[shared]``.
         :type filter_deleted: bool, optional
         :param _return_http_data_only: Response data without head status

--- a/src/datadog_api_client/v1/api/events_api.py
+++ b/src/datadog_api_client/v1/api/events_api.py
@@ -183,8 +183,8 @@ class EventsApi:
 
         This endpoint allows you to query for event details.
 
-        **Note**\ : If the event you’re querying contains markdown formatting of any kind,
-        you may see characters such as ``%``\ ,\ ``\``\ ,\ ``n`` in your output.
+        **Note** : If the event you’re querying contains markdown formatting of any kind,
+        you may see characters such as ``%`` , ``\`` , ``n`` in your output.
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True.
@@ -230,12 +230,12 @@ class EventsApi:
 
         The event stream can be queried and filtered by time, priority, sources and tags.
 
-        **Notes**\ :
+        **Notes** :
 
 
         *
           If the event you’re querying contains markdown formatting of any kind,
-          you may see characters such as ``%``\ ,\ ``\``\ ,\ ``n`` in your output.
+          you may see characters such as ``%`` , ``\`` , ``n`` in your output.
 
         *
           This endpoint returns a maximum of ``1000`` most recent results. To return additional results,
@@ -258,11 +258,11 @@ class EventsApi:
         :type sources: str, optional
         :param tags: A comma separated list indicating what tags, if any, should be used to filter the list of monitors by scope.
         :type tags: str, optional
-        :param unaggregated: Set unaggregated to ``true`` to return all events within the specified [\ ``start``\ ,\ ``end``\ ] timeframe.
+        :param unaggregated: Set unaggregated to ``true`` to return all events within the specified [ ``start`` , ``end`` ] timeframe.
             Otherwise if an event is aggregated to a parent event with a timestamp outside of the timeframe,
             it won't be available in the output. Aggregated events with ``is_aggregate=true`` in the response will still be returned unless exclude_aggregate is set to ``true.``
         :type unaggregated: bool, optional
-        :param exclude_aggregate: Set ``exclude_aggregate`` to ``true`` to only return unaggregated events where ``is_aggregate=false`` in the response. If the ``exclude_aggregate`` parameter is set to ``true``\ ,
+        :param exclude_aggregate: Set ``exclude_aggregate`` to ``true`` to only return unaggregated events where ``is_aggregate=false`` in the response. If the ``exclude_aggregate`` parameter is set to ``true`` ,
             then the unaggregated parameter is ignored and will be ``true`` by default.
         :type exclude_aggregate: bool, optional
         :param page: By default 1000 results are returned per request. Set page to the number of the page to return with ``0`` being the first page. The page parameter can only be used

--- a/src/datadog_api_client/v1/api/gcp_integration_api.py
+++ b/src/datadog_api_client/v1/api/gcp_integration_api.py
@@ -232,8 +232,8 @@ class GCPIntegrationApi:
         """Update a GCP integration.
 
         Update a Datadog-GCP integrations host_filters and/or auto-mute.
-        Requires a ``project_id`` and ``client_email``\ , however these fields cannot be updated.
-        If you need to update these fields, delete and use the create (\ ``POST``\ ) endpoint.
+        Requires a ``project_id`` and ``client_email`` , however these fields cannot be updated.
+        If you need to update these fields, delete and use the create ( ``POST`` ) endpoint.
         The unspecified fields will keep their original values.
 
         This method makes a synchronous HTTP request by default. To make an

--- a/src/datadog_api_client/v1/api/logs_api.py
+++ b/src/datadog_api_client/v1/api/logs_api.py
@@ -129,9 +129,9 @@ class LogsApi:
         List endpoint returns logs that match a log search query.
         `Results are paginated </logs/guide/collect-multiple-logs-with-pagination>`_.
 
-        **If you are considering archiving logs for your organization,
+        If you are considering archiving logs for your organization,
         consider use of the Datadog archive capabilities instead of the log list API.
-        See `Datadog Logs Archive documentation <https://docs.datadoghq.com/logs/archives>`_.**
+        See `Datadog Logs Archive documentation <https://docs.datadoghq.com/logs/archives>`_.
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True.

--- a/src/datadog_api_client/v1/api/logs_pipelines_api.py
+++ b/src/datadog_api_client/v1/api/logs_pipelines_api.py
@@ -422,7 +422,7 @@ class LogsPipelinesApi:
 
         Update a given pipeline configuration to change it’s processors or their order.
 
-        **Note**\ : Using this method updates your pipeline configuration by **replacing**
+        **Note** : Using this method updates your pipeline configuration by **replacing**
         your current configuration with the new one sent to your Datadog organization.
 
         This method makes a synchronous HTTP request by default. To make an
@@ -474,7 +474,7 @@ class LogsPipelinesApi:
         Update the order of your pipelines. Since logs are processed sequentially, reordering a pipeline may change
         the structure and content of the data processed by other pipelines and their processors.
 
-        **Note**\ : Using the ``PUT`` method updates your pipeline order by replacing your current order
+        **Note** : Using the ``PUT`` method updates your pipeline order by replacing your current order
         with the new one sent to your Datadog organization.
 
         This method makes a synchronous HTTP request by default. To make an

--- a/src/datadog_api_client/v1/api/metrics_api.py
+++ b/src/datadog_api_client/v1/api/metrics_api.py
@@ -23,7 +23,7 @@ class MetricsApi:
     * Modify tag configurations for metrics
     * View tags and volumes for metrics
 
-    **Note**\ : A graph can only contain a set number of points
+    **Note** : A graph can only contain a set number of points
     and as the timeframe over which a metric is viewed increases,
     aggregation between points occurs to stay below that set number.
 

--- a/src/datadog_api_client/v1/api/monitors_api.py
+++ b/src/datadog_api_client/v1/api/monitors_api.py
@@ -429,13 +429,13 @@ class MonitorsApi:
         Example: ``time_aggr(time_window):space_aggr:metric{tags} [by {key}] operator #``
 
 
-        * ``time_aggr``\ : avg, sum, max, min, change, or pct_change
-        * ``time_window``\ : ``last_#m`` (with ``#`` between 1 and 10080 depending on the monitor type) or ``last_#h``\ (with ``#`` between 1 and 168 depending on the monitor type) or ``last_1d``\ , or ``last_1w``
-        * ``space_aggr``\ : avg, sum, min, or max
-        * ``tags``\ : one or more tags (comma-separated), or *
+        * ``time_aggr`` : avg, sum, max, min, change, or pct_change
+        * ``time_window`` : ``last_#m`` (with ``#`` between 1 and 10080 depending on the monitor type) or ``last_#h`` (with ``#`` between 1 and 168 depending on the monitor type) or ``last_1d`` , or ``last_1w``
+        * ``space_aggr`` : avg, sum, min, or max
+        * ``tags`` : one or more tags (comma-separated), or *
         * `key`: a 'key' in key:value tag syntax; defines a separate alert for each tag in the group (multi-alert)
-        * ``operator``\ : <, <=, >, >=, ==, or !=
-        * ``#``\ : an integer or decimal number used to set the threshold
+        * ``operator`` : <, <=, >, >=, ==, or !=
+        * ``#`` : an integer or decimal number used to set the threshold
 
         If you are using the ``_change_`` or ``_pct_change_`` time aggregator, instead use ``change_aggr(time_aggr(time_window),
         timeshift):space_aggr:metric{tags} [by {key}] operator #`` with:
@@ -455,18 +455,18 @@ class MonitorsApi:
 
 
         * ``check`` name of the check, for example ``datadog.agent.up``
-        * ``tags`` one or more quoted tags (comma-separated), or "*". for example: ``.over("env:prod", "role:db")``\ ; ``over`` cannot be blank.
-        * ``count`` must be at greater than or equal to your max threshold (defined in the ``options``\ ). It is limited to 100.
+        * ``tags`` one or more quoted tags (comma-separated), or "*". for example: ``.over("env:prod", "role:db")`` ; ``over`` cannot be blank.
+        * ``count`` must be at greater than or equal to your max threshold (defined in the ``options`` ). It is limited to 100.
           For example, if you've specified to notify on 1 critical, 3 ok, and 2 warn statuses, ``count`` should be at least 3.
         * ``group`` must be specified for check monitors. Per-check grouping is already explicitly known for some service checks.
-          For example, Postgres integration monitors are tagged by ``db``\ , ``host``\ , and ``port``\ , and Network monitors by ``host``\ , ``instance``\ , and ``url``. See `Service Checks <https://docs.datadoghq.com/api/latest/service-checks/>`_ documentation for more information.
+          For example, Postgres integration monitors are tagged by ``db`` , ``host`` , and ``port`` , and Network monitors by ``host`` , ``instance`` , and ``url``. See `Service Checks <https://docs.datadoghq.com/api/latest/service-checks/>`_ documentation for more information.
 
         **Event Alert Query**
 
         Example: ``events('sources:nagios status:error,warning priority:normal tags: "string query"').rollup("count").last("1h")"``
 
 
-        * ``event``\ , the event query string:
+        * ``event`` , the event query string:
         * ``string_query`` free text query to match against event title and text.
         * ``sources`` event sources (comma-separated).
         * ``status`` event statuses (comma-separated). Valid options: error, warn, and info.
@@ -485,10 +485,10 @@ class MonitorsApi:
 
 
         * ``query`` The search query - following the `Log search syntax <https://docs.datadoghq.com/logs/search_syntax/>`_.
-        * ``rollup_method`` The stats roll-up method - supports ``count``\ , ``avg`` and ``cardinality``.
+        * ``rollup_method`` The stats roll-up method - supports ``count`` , ``avg`` and ``cardinality``.
         * ``measure`` For ``avg`` and cardinality ``rollup_method`` - specify the measure or the facet name you want to use.
         * ``time_window`` #m (between 1 and 2880), #h (between 1 and 48).
-        * ``operator`` ``<``\ , ``<=``\ , ``>``\ , ``>=``\ , ``==``\ , or ``!=``.
+        * ``operator`` ``<`` , ``<=`` , ``>`` , ``>=`` , ``==`` , or ``!=``.
         * ``#`` an integer or decimal number used to set the threshold.
 
         **Process Alert Query**
@@ -510,21 +510,21 @@ class MonitorsApi:
 
         * ``query`` The search query - following the `Log search syntax <https://docs.datadoghq.com/logs/search_syntax/>`_.
         * ``index_name`` For multi-index organizations, the log index in which the request is performed.
-        * ``rollup_method`` The stats roll-up method - supports ``count``\ , ``avg`` and ``cardinality``.
+        * ``rollup_method`` The stats roll-up method - supports ``count`` , ``avg`` and ``cardinality``.
         * ``measure`` For ``avg`` and cardinality ``rollup_method`` - specify the measure or the facet name you want to use.
         * ``time_window`` #m (between 1 and 2880), #h (between 1 and 48).
-        * ``operator`` ``<``\ , ``<=``\ , ``>``\ , ``>=``\ , ``==``\ , or ``!=``.
+        * ``operator`` ``<`` , ``<=`` , ``>`` , ``>=`` , ``==`` , or ``!=``.
         * ``#`` an integer or decimal number used to set the threshold.
 
         **Composite Query**
 
-        Example: ``12345 && 67890``\ , where ``12345`` and ``67890`` are the IDs of non-composite monitors
+        Example: ``12345 && 67890`` , where ``12345`` and ``67890`` are the IDs of non-composite monitors
 
 
-        * ``name`` [\ *required*\ , *default* = **dynamic, based on query**\ ]: The name of the alert.
-        * ``message`` [\ *required*\ , *default* = **dynamic, based on query**\ ]: A message to include with notifications for this monitor.
+        * ``name`` [ *required* , *default* = **dynamic, based on query** ]: The name of the alert.
+        * ``message`` [ *required* , *default* = **dynamic, based on query** ]: A message to include with notifications for this monitor.
           Email notifications can be sent to specific users by using the same '@username' notation as events.
-        * ``tags`` [\ *optional*\ , *default* = **empty list**\ ]: A list of tags to associate with your monitor.
+        * ``tags`` [ *optional* , *default* = **empty list** ]: A list of tags to associate with your monitor.
           When getting all monitor details via the API, use the ``monitor_tags`` argument to filter results by these tags.
           It is only available via the API and isn't visible or editable in the Datadog UI.
 
@@ -533,9 +533,9 @@ class MonitorsApi:
         Example: ``error_budget("slo_id").over("time_window") operator #``
 
 
-        * ``slo_id``\ : The alphanumeric SLO ID of the SLO you are configuring the alert for.
-        * `time_window`: The time window of the SLO target you wish to alert on. Valid options: ``7d``\ , ``30d``\ , ``90d``.
-        * ``operator``\ : ``>=`` or ``>``
+        * ``slo_id`` : The alphanumeric SLO ID of the SLO you are configuring the alert for.
+        * `time_window`: The time window of the SLO target you wish to alert on. Valid options: ``7d`` , ``30d`` , ``90d``.
+        * ``operator`` : ``>=`` or ``>``
 
         **Audit Alert Query**
 
@@ -543,10 +543,10 @@ class MonitorsApi:
 
 
         * ``query`` The search query - following the `Log search syntax <https://docs.datadoghq.com/logs/search_syntax/>`_.
-        * ``rollup_method`` The stats roll-up method - supports ``count``\ , ``avg`` and ``cardinality``.
+        * ``rollup_method`` The stats roll-up method - supports ``count`` , ``avg`` and ``cardinality``.
         * ``measure`` For ``avg`` and cardinality ``rollup_method`` - specify the measure or the facet name you want to use.
         * ``time_window`` #m (between 1 and 2880), #h (between 1 and 48).
-        * ``operator`` ``<``\ , ``<=``\ , ``>``\ , ``>=``\ , ``==``\ , or ``!=``.
+        * ``operator`` ``<`` , ``<=`` , ``>`` , ``>=`` , ``==`` , or ``!=``.
         * ``#`` an integer or decimal number used to set the threshold.
 
         **NOTE** Only available on US1-FED and in closed beta on US1, EU, US3, and US5.
@@ -557,10 +557,10 @@ class MonitorsApi:
 
 
         * ``query`` The search query - following the `Log search syntax <https://docs.datadoghq.com/logs/search_syntax/>`_.
-        * ``rollup_method`` The stats roll-up method - supports ``count``\ , ``avg``\ , and ``cardinality``.
+        * ``rollup_method`` The stats roll-up method - supports ``count`` , ``avg`` , and ``cardinality``.
         * ``measure`` For ``avg`` and cardinality ``rollup_method`` - specify the measure or the facet name you want to use.
         * ``time_window`` #m (between 1 and 2880), #h (between 1 and 48).
-        * ``operator`` ``<``\ , ``<=``\ , ``>``\ , ``>=``\ , ``==``\ , or ``!=``.
+        * ``operator`` ``<`` , ``<=`` , ``>`` , ``>=`` , ``==`` , or ``!=``.
         * ``#`` an integer or decimal number used to set the threshold.
 
         **NOTE** CI Pipeline monitors are in alpha on US1, EU, US3 and US5.
@@ -571,10 +571,10 @@ class MonitorsApi:
 
 
         * ``query`` The search query - following the `Log search syntax <https://docs.datadoghq.com/logs/search_syntax/>`_.
-        * ``rollup_method`` The stats roll-up method - supports ``count``\ , ``avg``\ , and ``cardinality``.
+        * ``rollup_method`` The stats roll-up method - supports ``count`` , ``avg`` , and ``cardinality``.
         * ``measure`` For ``avg`` and cardinality ``rollup_method`` - specify the measure or the facet name you want to use.
         * ``time_window`` #m (between 1 and 2880), #h (between 1 and 48).
-        * ``operator`` ``<``\ , ``<=``\ , ``>``\ , ``>=``\ , ``==``\ , or ``!=``.
+        * ``operator`` ``<`` , ``<=`` , ``>`` , ``>=`` , ``==`` , or ``!=``.
         * ``#`` an integer or decimal number used to set the threshold.
 
         **NOTE** CI Test monitors are available only in closed beta on US1, EU, US3 and US5.
@@ -586,10 +586,10 @@ class MonitorsApi:
 
 
         * ``query`` The search query - following the `Log search syntax <https://docs.datadoghq.com/logs/search_syntax/>`_.
-        * ``rollup_method`` The stats roll-up method - supports ``count``\ , ``avg``\ , and ``cardinality``.
+        * ``rollup_method`` The stats roll-up method - supports ``count`` , ``avg`` , and ``cardinality``.
         * ``measure`` For ``avg`` and cardinality ``rollup_method`` - specify the measure or the facet name you want to use.
         * ``time_window`` #m (between 1 and 2880), #h (between 1 and 48).
-        * ``operator`` ``<``\ , ``<=``\ , ``>``\ , ``>=``\ , ``==``\ , or ``!=``.
+        * ``operator`` ``<`` , ``<=`` , ``>`` , ``>=`` , ``==`` , or ``!=``.
         * ``#`` an integer or decimal number used to set the threshold.
 
         This method makes a synchronous HTTP request by default. To make an
@@ -690,7 +690,7 @@ class MonitorsApi:
 
         :param monitor_id: The ID of the monitor
         :type monitor_id: int
-        :param group_states: When specified, shows additional information about the group states. Choose one or more from ``all``\ , ``alert``\ , ``warn``\ , and ``no data``.
+        :param group_states: When specified, shows additional information about the group states. Choose one or more from ``all`` , ``alert`` , ``warn`` , and ``no data``.
         :type group_states: str, optional
         :param _return_http_data_only: Response data without head status
             code and headers. Default is True.
@@ -735,7 +735,7 @@ class MonitorsApi:
         >>> result = thread.get()
 
         :param group_states: When specified, shows additional information about the group states.
-            Choose one or more from ``all``\ , ``alert``\ , ``warn``\ , and ``no data``.
+            Choose one or more from ``all`` , ``alert`` , ``warn`` , and ``no data``.
         :type group_states: str, optional
         :param name: A string to filter monitors by name.
         :type name: str, optional
@@ -803,7 +803,7 @@ class MonitorsApi:
         :type page: int, optional
         :param per_page: Number of monitors to return per page.
         :type per_page: int, optional
-        :param sort: String for sort order, composed of field and sort order separate by a comma, for example ``name,asc``. Supported sort directions: ``asc``\ , ``desc``. Supported fields:
+        :param sort: String for sort order, composed of field and sort order separate by a comma, for example ``name,asc``. Supported sort directions: ``asc`` , ``desc``. Supported fields:
 
 
             * ``name``
@@ -860,7 +860,7 @@ class MonitorsApi:
         :type page: int, optional
         :param per_page: Number of monitors to return per page.
         :type per_page: int, optional
-        :param sort: String for sort order, composed of field and sort order separate by a comma, for example ``name,asc``. Supported sort directions: ``asc``\ , ``desc``. Supported fields:
+        :param sort: String for sort order, composed of field and sort order separate by a comma, for example ``name,asc``. Supported sort directions: ``asc`` , ``desc``. Supported fields:
 
 
             * ``name``

--- a/src/datadog_api_client/v1/api/notebooks_api.py
+++ b/src/datadog_api_client/v1/api/notebooks_api.py
@@ -341,7 +341,7 @@ class NotebooksApi:
         :type start: int, optional
         :param count: The number of notebooks to be returned.
         :type count: int, optional
-        :param sort_field: Sort by field ``modified``\ , ``name``\ , or ``created``.
+        :param sort_field: Sort by field ``modified`` , ``name`` , or ``created``.
         :type sort_field: str, optional
         :param sort_dir: Sort by direction ``asc`` or ``desc``.
         :type sort_dir: str, optional

--- a/src/datadog_api_client/v1/api/organizations_api.py
+++ b/src/datadog_api_client/v1/api/organizations_api.py
@@ -155,7 +155,7 @@ class OrganizationsApi:
         `contacting support <https://docs.datadoghq.com/help/>`_.
 
         Once a new child organization is created, you can interact with it
-        by using the ``org.public_id``\ , ``api_key.key``\ , and
+        by using the ``org.public_id`` , ``api_key.key`` , and
         ``application_key.hash`` provided in the response.
 
         This method makes a synchronous HTTP request by default. To make an
@@ -336,7 +336,7 @@ class OrganizationsApi:
 
 
         *
-          **Multipart Form-Data**\ : Post the IdP metadata file using a form post.
+          **Multipart Form-Data** : Post the IdP metadata file using a form post.
 
         *
           **XML Body:** Post the IdP metadata file as the body of the request.

--- a/src/datadog_api_client/v1/api/service_checks_api.py
+++ b/src/datadog_api_client/v1/api/service_checks_api.py
@@ -56,7 +56,7 @@ class ServiceChecksApi:
 
         Submit a list of Service Checks.
 
-        **Notes**\ :
+        **Notes** :
 
 
         * A valid API key is required.

--- a/src/datadog_api_client/v1/api/service_level_objectives_api.py
+++ b/src/datadog_api_client/v1/api/service_level_objectives_api.py
@@ -612,7 +612,7 @@ class ServiceLevelObjectivesApi:
         :type to_ts: int
         :param target: The SLO target. If ``target`` is passed in, the response will include the remaining error budget and a timeframe value of ``custom``.
         :type target: float, optional
-        :param apply_correction: Defaults to ``true``. If any SLO corrections are applied and this parameter is set to ``false``\ ,
+        :param apply_correction: Defaults to ``true``. If any SLO corrections are applied and this parameter is set to ``false`` ,
             then the corrections will not be applied and the SLI values will not be affected.
         :type apply_correction: bool, optional
         :param _return_http_data_only: Response data without head status

--- a/src/datadog_api_client/v1/api/snapshots_api.py
+++ b/src/datadog_api_client/v1/api/snapshots_api.py
@@ -72,7 +72,7 @@ class SnapshotsApi:
         """Take graph snapshots.
 
         Take graph snapshots.
-        **Note**\ : When a snapshot is created, there is some delay before it is available.
+        **Note** : When a snapshot is created, there is some delay before it is available.
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True.

--- a/src/datadog_api_client/v1/api/tags_api.py
+++ b/src/datadog_api_client/v1/api/tags_api.py
@@ -13,7 +13,7 @@ class TagsApi:
     The tag endpoint allows you to assign tags to hosts,
     for example: ``role:database``. Those tags are applied to
     all metrics sent by the host. Refer to hosts by name
-    (\ ``yourhost.example.com``\ ) when fetching and applying
+    ( ``yourhost.example.com`` ) when fetching and applying
     tags to a particular host.
 
     The component of your infrastructure responsible for a tag is identified

--- a/src/datadog_api_client/v1/api/usage_metering_api.py
+++ b/src/datadog_api_client/v1/api/usage_metering_api.py
@@ -62,7 +62,7 @@ class UsageMeteringApi:
     This API is available to all Pro and Enterprise customers.
     Usage is only accessible for `parent-level organizations <https://docs.datadoghq.com/account_management/multi_organization/>`_.
 
-    **Note**\ : Usage data is delayed by up to 72 hours from when it was incurred.
+    **Note** : Usage data is delayed by up to 72 hours from when it was incurred.
     It is retained for 15 months.
 
     You can retrieve up to 24 hours of hourly usage data for multiple organizations,

--- a/src/datadog_api_client/v1/api/users_api.py
+++ b/src/datadog_api_client/v1/api/users_api.py
@@ -141,7 +141,7 @@ class UsersApi:
 
         Create a user for your organization.
 
-        **Note**\ : Users can only be created with the admin access role
+        **Note** : Users can only be created with the admin access role
         if application keys belong to administrators.
 
         This method makes a synchronous HTTP request by default. To make an
@@ -188,7 +188,7 @@ class UsersApi:
 
         Delete a user from an organization.
 
-        **Note**\ : This endpoint can only be used with application keys belonging to
+        **Note** : This endpoint can only be used with application keys belonging to
         administrators.
 
         This method makes a synchronous HTTP request by default. To make an
@@ -319,7 +319,7 @@ class UsersApi:
 
         Update a user information.
 
-        **Note**\ : It can only be used with application keys belonging to administrators.
+        **Note** : It can only be used with application keys belonging to administrators.
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True.

--- a/src/datadog_api_client/v1/model/aws_account.py
+++ b/src/datadog_api_client/v1/model/aws_account.py
@@ -50,7 +50,7 @@ class AWSAccount(ModelNormal):
         :param account_id: Your AWS Account ID without dashes.
         :type account_id: str, optional
 
-        :param account_specific_namespace_rules: An object, (in the form ``{"namespace1":true/false, "namespace2":true/false}``\ ),
+        :param account_specific_namespace_rules: An object, (in the form ``{"namespace1":true/false, "namespace2":true/false}`` ),
             that enables or disables metric collection for specific AWS namespaces for this
             AWS account only.
         :type account_specific_namespace_rules: {str: (bool,)}, optional
@@ -61,7 +61,7 @@ class AWSAccount(ModelNormal):
         :param excluded_regions: An array of AWS regions to exclude from metrics collection.
         :type excluded_regions: [str], optional
 
-        :param filter_tags: The array of EC2 tags (in the form ``key:value``\ ) defines a filter that Datadog uses when collecting metrics from EC2.
+        :param filter_tags: The array of EC2 tags (in the form ``key:value`` ) defines a filter that Datadog uses when collecting metrics from EC2.
             Wildcards, such as ``?`` (for single characters) and ``*`` (for multiple characters) can also be used.
             Only hosts that match one of the defined tags
             will be imported into Datadog. The rest will be ignored.
@@ -69,7 +69,7 @@ class AWSAccount(ModelNormal):
             For example, ``env:production,instance-type:c1.*,!region:us-east-1``
         :type filter_tags: [str], optional
 
-        :param host_tags: Array of tags (in the form ``key:value``\ ) to add to all hosts
+        :param host_tags: Array of tags (in the form ``key:value`` ) to add to all hosts
             and metrics reporting through this integration.
         :type host_tags: [str], optional
 

--- a/src/datadog_api_client/v1/model/cancel_downtimes_by_scope_request.py
+++ b/src/datadog_api_client/v1/model/cancel_downtimes_by_scope_request.py
@@ -26,7 +26,7 @@ class CancelDowntimesByScopeRequest(ModelNormal):
 
         :param scope: The scope(s) to which the downtime applies. For example, ``host:app2``.
             Provide multiple scopes as a comma-separated list like ``env:dev,env:prod``.
-            The resulting downtime applies to sources that matches ALL provided scopes (\ ``env:dev`` **AND** ``env:prod``\ ).
+            The resulting downtime applies to sources that matches ALL provided scopes ( ``env:dev`` **AND** ``env:prod`` ).
         :type scope: str
         """
         super().__init__(kwargs)

--- a/src/datadog_api_client/v1/model/downtime.py
+++ b/src/datadog_api_client/v1/model/downtime.py
@@ -145,7 +145,7 @@ class Downtime(ModelNormal):
 
         :param scope: The scope(s) to which the downtime applies. For example, ``host:app2``.
             Provide multiple scopes as a comma-separated list like ``env:dev,env:prod``.
-            The resulting downtime applies to sources that matches ALL provided scopes (\ ``env:dev`` **AND** ``env:prod``\ ).
+            The resulting downtime applies to sources that matches ALL provided scopes ( ``env:dev`` **AND** ``env:prod`` ).
         :type scope: [str], optional
 
         :param start: POSIX timestamp to start the downtime.

--- a/src/datadog_api_client/v1/model/downtime_child.py
+++ b/src/datadog_api_client/v1/model/downtime_child.py
@@ -135,7 +135,7 @@ class DowntimeChild(ModelNormal):
 
         :param scope: The scope(s) to which the downtime applies. For example, ``host:app2``.
             Provide multiple scopes as a comma-separated list like ``env:dev,env:prod``.
-            The resulting downtime applies to sources that matches ALL provided scopes (\ ``env:dev`` **AND** ``env:prod``\ ).
+            The resulting downtime applies to sources that matches ALL provided scopes ( ``env:dev`` **AND** ``env:prod`` ).
         :type scope: [str], optional
 
         :param start: POSIX timestamp to start the downtime.

--- a/src/datadog_api_client/v1/model/downtime_recurrence.py
+++ b/src/datadog_api_client/v1/model/downtime_recurrence.py
@@ -49,15 +49,15 @@ class DowntimeRecurrence(ModelNormal):
             For example, to repeat every 3 days, select a type of ``days`` and a period of ``3``.
         :type period: int, optional
 
-        :param rrule: The ``RRULE`` standard for defining recurring events (\ **requires to set "type" to rrule**\ )
+        :param rrule: The ``RRULE`` standard for defining recurring events ( **requires to set "type" to rrule** )
             For example, to have a recurring event on the first day of each month, set the type to ``rrule`` and set the ``FREQ`` to ``MONTHLY`` and ``BYMONTHDAY`` to ``1``.
             Most common ``rrule`` options from the `iCalendar Spec <https://tools.ietf.org/html/rfc5545>`_ are supported.
 
-            **Note**\ : Attributes specifying the duration in ``RRULE`` are not supported (for example, ``DTSTART``\ , ``DTEND``\ , ``DURATION``\ ).
+            **Note** : Attributes specifying the duration in ``RRULE`` are not supported (for example, ``DTSTART`` , ``DTEND`` , ``DURATION`` ).
             More examples available in this `downtime guide <https://docs.datadoghq.com/monitors/guide/suppress-alert-with-downtimes/?tab=api>`_
         :type rrule: str, optional
 
-        :param type: The type of recurrence. Choose from ``days``\ , ``weeks``\ , ``months``\ , ``years``\ , ``rrule``.
+        :param type: The type of recurrence. Choose from ``days`` , ``weeks`` , ``months`` , ``years`` , ``rrule``.
         :type type: str, optional
 
         :param until_date: The date at which the recurrence should end as a POSIX timestamp.
@@ -68,7 +68,7 @@ class DowntimeRecurrence(ModelNormal):
             ``until_occurences`` and ``until_date`` are mutually exclusive.
         :type until_occurrences: int, none_type, optional
 
-        :param week_days: A list of week days to repeat on. Choose from ``Mon``\ , ``Tue``\ , ``Wed``\ , ``Thu``\ , ``Fri``\ , ``Sat`` or ``Sun``.
+        :param week_days: A list of week days to repeat on. Choose from ``Mon`` , ``Tue`` , ``Wed`` , ``Thu`` , ``Fri`` , ``Sat`` or ``Sun``.
             Only applicable when type is weeks. First letter must be capitalized.
         :type week_days: [str], none_type, optional
         """

--- a/src/datadog_api_client/v1/model/event.py
+++ b/src/datadog_api_client/v1/model/event.py
@@ -70,8 +70,8 @@ class Event(ModelNormal):
         Object representing an event.
 
         :param alert_type: If an alert event is enabled, set its type.
-            For example, ``error``\ , ``warning``\ , ``info``\ , ``success``\ , ``user_update``\ ,
-            ``recommendation``\ , and ``snapshot``.
+            For example, ``error`` , ``warning`` , ``info`` , ``success`` , ``user_update`` ,
+            ``recommendation`` , and ``snapshot``.
         :type alert_type: EventAlertType, optional
 
         :param date_happened: POSIX timestamp of the event. Must be sent as an integer (that is no quotes).

--- a/src/datadog_api_client/v1/model/event_create_request.py
+++ b/src/datadog_api_client/v1/model/event_create_request.py
@@ -67,8 +67,8 @@ class EventCreateRequest(ModelNormal):
         :type aggregation_key: str, optional
 
         :param alert_type: If an alert event is enabled, set its type.
-            For example, ``error``\ , ``warning``\ , ``info``\ , ``success``\ , ``user_update``\ ,
-            ``recommendation``\ , and ``snapshot``.
+            For example, ``error`` , ``warning`` , ``info`` , ``success`` , ``user_update`` ,
+            ``recommendation`` , and ``snapshot``.
         :type alert_type: EventAlertType, optional
 
         :param date_happened: POSIX timestamp of the event. Must be sent as an integer (that is no quotes).

--- a/src/datadog_api_client/v1/model/image_widget_definition.py
+++ b/src/datadog_api_client/v1/model/image_widget_definition.py
@@ -65,11 +65,11 @@ class ImageWidgetDefinition(ModelNormal):
         :type horizontal_align: WidgetHorizontalAlign, optional
 
         :param margin: Size of the margins around the image.
-            **Note**\ : ``small`` and ``large`` values are deprecated.
+            **Note** : ``small`` and ``large`` values are deprecated.
         :type margin: WidgetMargin, optional
 
         :param sizing: How to size the image on the widget. The values are based on the image ``object-fit`` CSS properties.
-            **Note**\ : ``zoom``\ , ``fit`` and ``center`` values are deprecated.
+            **Note** : ``zoom`` , ``fit`` and ``center`` values are deprecated.
         :type sizing: WidgetImageSizing, optional
 
         :param type: Type of the image widget.

--- a/src/datadog_api_client/v1/model/logs_arithmetic_processor.py
+++ b/src/datadog_api_client/v1/model/logs_arithmetic_processor.py
@@ -44,7 +44,7 @@ class LogsArithmeticProcessor(ModelNormal):
         This enables you to remap different time attributes with different units into a single attribute,
         or to compute operations on attributes within the same log.
 
-        The formula can use parentheses and the basic arithmetic operators ``-``\ , ``+``\ , ``*``\ , ``/``.
+        The formula can use parentheses and the basic arithmetic operators ``-`` , ``+`` , ``*`` , ``/``.
 
         By default, the calculation is skipped if an attribute is missing.
         Select “Replace missing attribute by 0” to automatically populate
@@ -52,12 +52,12 @@ class LogsArithmeticProcessor(ModelNormal):
         An attribute is missing if it is not found in the log attributes,
         or if it cannot be converted to a number.
 
-        *Notes*\ :
+        *Notes* :
 
 
         * The operator ``-`` needs to be space split in the formula as it can also be contained in attribute names.
         * If the target attribute already exists, it is overwritten by the result of the formula.
-        * Results are rounded up to the 9th decimal. For example, if the result of the formula is ``0.1234567891``\ ,
+        * Results are rounded up to the 9th decimal. For example, if the result of the formula is ``0.1234567891`` ,
           the actual value stored for the attribute is ``0.123456789``.
         * If you need to scale a unit of measure,
           see `Scale Filter <https://docs.datadoghq.com/logs/log_configuration/parsing/?tab=filter#matcher-and-filter>`_.
@@ -68,7 +68,7 @@ class LogsArithmeticProcessor(ModelNormal):
         :param is_enabled: Whether or not the processor is enabled.
         :type is_enabled: bool, optional
 
-        :param is_replace_missing: If ``true``\ , it replaces all missing attributes of expression by ``0``\ , ``false``
+        :param is_replace_missing: If ``true`` , it replaces all missing attributes of expression by ``0`` , ``false``
             skip the operation if an attribute is missing.
         :type is_replace_missing: bool, optional
 

--- a/src/datadog_api_client/v1/model/logs_attribute_remapper.py
+++ b/src/datadog_api_client/v1/model/logs_attribute_remapper.py
@@ -74,9 +74,9 @@ class LogsAttributeRemapper(ModelNormal):
         :param target: Final attribute or tag name to remap the sources to.
         :type target: str
 
-        :param target_format: If the ``target_type`` of the remapper is ``attribute``\ , try to cast the value to a new specific type.
-            If the cast is not possible, the original type is kept. ``string``\ , ``integer``\ , or ``double`` are the possible types.
-            If the ``target_type`` is ``tag``\ , this parameter may not be specified.
+        :param target_format: If the ``target_type`` of the remapper is ``attribute`` , try to cast the value to a new specific type.
+            If the cast is not possible, the original type is kept. ``string`` , ``integer`` , or ``double`` are the possible types.
+            If the ``target_type`` is ``tag`` , this parameter may not be specified.
         :type target_format: TargetFormatType, optional
 
         :param target_type: Defines if the final attribute or tag name is from log ``attribute`` or ``tag``.

--- a/src/datadog_api_client/v1/model/logs_category_processor.py
+++ b/src/datadog_api_client/v1/model/logs_category_processor.py
@@ -43,7 +43,7 @@ class LogsCategoryProcessor(ModelNormal):
         to a log matching a provided search query. Use categories to create groups for an analytical view.
         For example, URL groups, machine groups, environments, and response time buckets.
 
-        **Notes**\ :
+        **Notes** :
 
 
         * The syntax of the query is the one of Logs Explorer search bar.

--- a/src/datadog_api_client/v1/model/logs_exclusion_filter.py
+++ b/src/datadog_api_client/v1/model/logs_exclusion_filter.py
@@ -26,7 +26,7 @@ class LogsExclusionFilter(ModelNormal):
         """
         Exclusion filter is defined by a query, a sampling rule, and a active/inactive toggle.
 
-        :param query: Default query is ``*``\ , meaning all logs flowing in the index would be excluded.
+        :param query: Default query is ``*`` , meaning all logs flowing in the index would be excluded.
             Scope down exclusion filter to only a subset of logs with a log query.
         :type query: str, optional
 

--- a/src/datadog_api_client/v1/model/logs_list_request.py
+++ b/src/datadog_api_client/v1/model/logs_list_request.py
@@ -65,7 +65,7 @@ class LogsListRequest(ModelNormal):
         :param start_at: Hash identifier of the first log to return in the list, available in a log ``id`` attribute.
             This parameter is used for the pagination feature.
 
-            **Note**\ : This parameter is ignored if the corresponding log
+            **Note** : This parameter is ignored if the corresponding log
             is out of the scope of the specified time window.
         :type start_at: str, optional
 

--- a/src/datadog_api_client/v1/model/logs_pipeline.py
+++ b/src/datadog_api_client/v1/model/logs_pipeline.py
@@ -51,7 +51,7 @@ class LogsPipeline(ModelNormal):
         Pipelines and processors operate on incoming logs,
         parsing and transforming them into structured attributes for easier querying.
 
-        **Note**\ : These endpoints are only available for admin users.
+        **Note** : These endpoints are only available for admin users.
         Make sure to use an application key created by an admin.
 
         :param filter: Filter for logs.

--- a/src/datadog_api_client/v1/model/logs_status_remapper.py
+++ b/src/datadog_api_client/v1/model/logs_status_remapper.py
@@ -48,7 +48,7 @@ class LogsStatusRemapper(ModelNormal):
         * Strings beginning with ``w`` (case-insensitive) map to ``warning`` (4)
         * Strings beginning with ``n`` (case-insensitive) map to ``notice`` (5)
         * Strings beginning with ``i`` (case-insensitive) map to ``info`` (6)
-        * Strings beginning with ``d``\ , ``trace`` or ``verbose`` (case-insensitive) map to ``debug`` (7)
+        * Strings beginning with ``d`` , ``trace`` or ``verbose`` (case-insensitive) map to ``debug`` (7)
         * Strings beginning with ``o`` or matching ``OK`` or ``Success`` (case-insensitive) map to OK
         *
           All others map to ``info`` (6)

--- a/src/datadog_api_client/v1/model/logs_string_builder_processor.py
+++ b/src/datadog_api_client/v1/model/logs_string_builder_processor.py
@@ -45,7 +45,7 @@ class LogsStringBuilderProcessor(ModelNormal):
 
         The template is defined by both raw text and blocks with the syntax ``%{attribute_path}``.
 
-        **Notes**\ :
+        **Notes** :
 
 
         * The processor only accepts attributes with values or an array of values in the blocks.

--- a/src/datadog_api_client/v1/model/metrics_query_metadata.py
+++ b/src/datadog_api_client/v1/model/metrics_query_metadata.py
@@ -117,8 +117,8 @@ class MetricsQueryMetadata(ModelNormal):
         :type tag_set: [str], optional
 
         :param unit: Detailed information about the metric unit.
-            First element describes the "primary unit" (for example, ``bytes`` in ``bytes per second``\ ),
-            second describes the "per unit" (for example, ``second`` in ``bytes per second``\ ).
+            First element describes the "primary unit" (for example, ``bytes`` in ``bytes per second`` ),
+            second describes the "per unit" (for example, ``second`` in ``bytes per second`` ).
         :type unit: [MetricsQueryUnit], optional
         """
         super().__init__(kwargs)

--- a/src/datadog_api_client/v1/model/monitor.py
+++ b/src/datadog_api_client/v1/model/monitor.py
@@ -94,7 +94,7 @@ class Monitor(ModelNormal):
         :param creator: Object describing the creator of the shared element.
         :type creator: Creator, optional
 
-        :param deleted: Whether or not the monitor is deleted. (Always ``null``\ )
+        :param deleted: Whether or not the monitor is deleted. (Always ``null`` )
         :type deleted: datetime, none_type, optional
 
         :param id: ID of this monitor.
@@ -124,7 +124,7 @@ class Monitor(ModelNormal):
         :param query: The monitor query.
         :type query: str
 
-        :param restricted_roles: A list of unique role identifiers to define which roles are allowed to edit the monitor. The unique identifiers for all roles can be pulled from the `Roles API <https://docs.datadoghq.com/api/latest/roles/#list-roles>`_ and are located in the ``data.id`` field. Editing a monitor includes any updates to the monitor configuration, monitor deletion, and muting of the monitor for any amount of time. ``restricted_roles`` is the successor of ``locked``. For more information about ``locked`` and ``restricted_roles``\ , see the `monitor options docs <https://docs.datadoghq.com/monitors/guide/monitor_api_options/#permissions-options>`_.
+        :param restricted_roles: A list of unique role identifiers to define which roles are allowed to edit the monitor. The unique identifiers for all roles can be pulled from the `Roles API <https://docs.datadoghq.com/api/latest/roles/#list-roles>`_ and are located in the ``data.id`` field. Editing a monitor includes any updates to the monitor configuration, monitor deletion, and muting of the monitor for any amount of time. ``restricted_roles`` is the successor of ``locked``. For more information about ``locked`` and ``restricted_roles`` , see the `monitor options docs <https://docs.datadoghq.com/monitors/guide/monitor_api_options/#permissions-options>`_.
         :type restricted_roles: [str], none_type, optional
 
         :param state: Wrapper object with the different monitor states.
@@ -133,7 +133,7 @@ class Monitor(ModelNormal):
         :param tags: Tags associated to your monitor.
         :type tags: [str], optional
 
-        :param type: The type of the monitor. For more information about ``type``\ , see the `monitor options <https://docs.datadoghq.com/monitors/guide/monitor_api_options/>`_ docs.
+        :param type: The type of the monitor. For more information about ``type`` , see the `monitor options <https://docs.datadoghq.com/monitors/guide/monitor_api_options/>`_ docs.
         :type type: MonitorType
         """
         super().__init__(kwargs)

--- a/src/datadog_api_client/v1/model/monitor_options.py
+++ b/src/datadog_api_client/v1/model/monitor_options.py
@@ -119,7 +119,7 @@ class MonitorOptions(ModelNormal):
         :param enable_logs_sample: Whether or not to send a log sample when the log monitor triggers.
         :type enable_logs_sample: bool, optional
 
-        :param escalation_message: We recommend using the `is_renotify <https://docs.datadoghq.com/monitors/notify/?tab=is_alert#renotify>`_\ ,
+        :param escalation_message: We recommend using the `is_renotify <https://docs.datadoghq.com/monitors/notify/?tab=is_alert#renotify>`_ ,
             block in the original message instead.
             A message to include with a re-notification. Supports the ``@username`` notification we allow elsewhere.
             Not applicable if ``renotify_interval`` is ``None``.
@@ -138,8 +138,8 @@ class MonitorOptions(ModelNormal):
             **Examples**
 
 
-            * If ``True``\ , ``[Triggered on {host:h1}] Monitor Title``
-            * If ``False``\ , ``[Triggered] Monitor Title``
+            * If ``True`` , ``[Triggered on {host:h1}] Monitor Title``
+            * If ``False`` , ``[Triggered] Monitor Title``
         :type include_tags: bool, optional
 
         :param locked: Whether or not the monitor is locked (only editable by creator and admins). Use ``restricted_roles`` instead.
@@ -149,7 +149,7 @@ class MonitorOptions(ModelNormal):
         :type min_failure_duration: int, none_type, optional
 
         :param min_location_failed: The minimum number of locations in failure at the same time during
-            at least one moment in the ``min_failure_duration`` period (\ ``min_location_failed`` and ``min_failure_duration``
+            at least one moment in the ``min_failure_duration`` period ( ``min_location_failed`` and ``min_failure_duration``
             are part of the advanced alerting rules - integer, >= 1).
         :type min_location_failed: int, none_type, optional
 

--- a/src/datadog_api_client/v1/model/monitor_search_result.py
+++ b/src/datadog_api_client/v1/model/monitor_search_result.py
@@ -104,7 +104,7 @@ class MonitorSearchResult(ModelNormal):
         :param scopes: The scope(s) to which the downtime applies, for example ``host:app2``.
             Provide multiple scopes as a comma-separated list, for example ``env:dev,env:prod``.
             The resulting downtime applies to sources that matches ALL provided scopes
-            (that is ``env:dev AND env:prod``\ ), NOT any of them.
+            (that is ``env:dev AND env:prod`` ), NOT any of them.
         :type scopes: [str], optional
 
         :param status: The different states your monitor can be in.
@@ -113,7 +113,7 @@ class MonitorSearchResult(ModelNormal):
         :param tags: Tags associated with the monitor.
         :type tags: [str], optional
 
-        :param type: The type of the monitor. For more information about ``type``\ , see the `monitor options <https://docs.datadoghq.com/monitors/guide/monitor_api_options/>`_ docs.
+        :param type: The type of the monitor. For more information about ``type`` , see the `monitor options <https://docs.datadoghq.com/monitors/guide/monitor_api_options/>`_ docs.
         :type type: MonitorType, optional
         """
         super().__init__(kwargs)

--- a/src/datadog_api_client/v1/model/monitor_update_request.py
+++ b/src/datadog_api_client/v1/model/monitor_update_request.py
@@ -94,7 +94,7 @@ class MonitorUpdateRequest(ModelNormal):
         :param creator: Object describing the creator of the shared element.
         :type creator: Creator, optional
 
-        :param deleted: Whether or not the monitor is deleted. (Always ``null``\ )
+        :param deleted: Whether or not the monitor is deleted. (Always ``null`` )
         :type deleted: datetime, none_type, optional
 
         :param id: ID of this monitor.
@@ -124,7 +124,7 @@ class MonitorUpdateRequest(ModelNormal):
         :param query: The monitor query.
         :type query: str, optional
 
-        :param restricted_roles: A list of unique role identifiers to define which roles are allowed to edit the monitor. The unique identifiers for all roles can be pulled from the `Roles API <https://docs.datadoghq.com/api/latest/roles/#list-roles>`_ and are located in the ``data.id`` field. Editing a monitor includes any updates to the monitor configuration, monitor deletion, and muting of the monitor for any amount of time. ``restricted_roles`` is the successor of ``locked``. For more information about ``locked`` and ``restricted_roles``\ , see the `monitor options docs <https://docs.datadoghq.com/monitors/guide/monitor_api_options/#permissions-options>`_.
+        :param restricted_roles: A list of unique role identifiers to define which roles are allowed to edit the monitor. The unique identifiers for all roles can be pulled from the `Roles API <https://docs.datadoghq.com/api/latest/roles/#list-roles>`_ and are located in the ``data.id`` field. Editing a monitor includes any updates to the monitor configuration, monitor deletion, and muting of the monitor for any amount of time. ``restricted_roles`` is the successor of ``locked``. For more information about ``locked`` and ``restricted_roles`` , see the `monitor options docs <https://docs.datadoghq.com/monitors/guide/monitor_api_options/#permissions-options>`_.
         :type restricted_roles: [str], optional
 
         :param state: Wrapper object with the different monitor states.
@@ -133,7 +133,7 @@ class MonitorUpdateRequest(ModelNormal):
         :param tags: Tags associated to your monitor.
         :type tags: [str], optional
 
-        :param type: The type of the monitor. For more information about ``type``\ , see the `monitor options <https://docs.datadoghq.com/monitors/guide/monitor_api_options/>`_ docs.
+        :param type: The type of the monitor. For more information about ``type`` , see the `monitor options <https://docs.datadoghq.com/monitors/guide/monitor_api_options/>`_ docs.
         :type type: MonitorType, optional
         """
         super().__init__(kwargs)

--- a/src/datadog_api_client/v1/model/notebook_cell_create_request.py
+++ b/src/datadog_api_client/v1/model/notebook_cell_create_request.py
@@ -35,7 +35,7 @@ class NotebookCellCreateRequest(ModelNormal):
         """
         The description of a notebook cell create request.
 
-        :param attributes: The attributes of a notebook cell in create cell request. Valid cell types are ``markdown``\ , ``timeseries``\ , ``toplist``\ , ``heatmap``\ , ``distribution``\ ,
+        :param attributes: The attributes of a notebook cell in create cell request. Valid cell types are ``markdown`` , ``timeseries`` , ``toplist`` , ``heatmap`` , ``distribution`` ,
             ``log_stream``. `More information on each graph visualization type. <https://docs.datadoghq.com/dashboards/widgets/>`_
         :type attributes: NotebookCellCreateRequestAttributes
 

--- a/src/datadog_api_client/v1/model/notebook_cell_create_request_attributes.py
+++ b/src/datadog_api_client/v1/model/notebook_cell_create_request_attributes.py
@@ -28,7 +28,7 @@ def lazy_import():
 class NotebookCellCreateRequestAttributes(ModelComposed):
     def __init__(self, *args, **kwargs):
         """
-        The attributes of a notebook cell in create cell request. Valid cell types are ``markdown``\ , ``timeseries``\ , ``toplist``\ , ``heatmap``\ , ``distribution``\ ,
+        The attributes of a notebook cell in create cell request. Valid cell types are ``markdown`` , ``timeseries`` , ``toplist`` , ``heatmap`` , ``distribution`` ,
         ``log_stream``. `More information on each graph visualization type. <https://docs.datadoghq.com/dashboards/widgets/>`_
 
         :param definition: Text in a notebook is formatted with [Markdown](https://daringfireball.net/projects/markdown/), which enables the use of headings, subheadings, links, images, lists, and code blocks.

--- a/src/datadog_api_client/v1/model/notebook_cell_response.py
+++ b/src/datadog_api_client/v1/model/notebook_cell_response.py
@@ -37,7 +37,7 @@ class NotebookCellResponse(ModelNormal):
         """
         The description of a notebook cell response.
 
-        :param attributes: The attributes of a notebook cell response. Valid cell types are ``markdown``\ , ``timeseries``\ , ``toplist``\ , ``heatmap``\ , ``distribution``\ ,
+        :param attributes: The attributes of a notebook cell response. Valid cell types are ``markdown`` , ``timeseries`` , ``toplist`` , ``heatmap`` , ``distribution`` ,
             ``log_stream``. `More information on each graph visualization type. <https://docs.datadoghq.com/dashboards/widgets/>`_
         :type attributes: NotebookCellResponseAttributes
 

--- a/src/datadog_api_client/v1/model/notebook_cell_response_attributes.py
+++ b/src/datadog_api_client/v1/model/notebook_cell_response_attributes.py
@@ -28,7 +28,7 @@ def lazy_import():
 class NotebookCellResponseAttributes(ModelComposed):
     def __init__(self, *args, **kwargs):
         """
-        The attributes of a notebook cell response. Valid cell types are ``markdown``\ , ``timeseries``\ , ``toplist``\ , ``heatmap``\ , ``distribution``\ ,
+        The attributes of a notebook cell response. Valid cell types are ``markdown`` , ``timeseries`` , ``toplist`` , ``heatmap`` , ``distribution`` ,
         ``log_stream``. `More information on each graph visualization type. <https://docs.datadoghq.com/dashboards/widgets/>`_
 
         :param definition: Text in a notebook is formatted with [Markdown](https://daringfireball.net/projects/markdown/), which enables the use of headings, subheadings, links, images, lists, and code blocks.

--- a/src/datadog_api_client/v1/model/notebook_cell_update_request.py
+++ b/src/datadog_api_client/v1/model/notebook_cell_update_request.py
@@ -37,7 +37,7 @@ class NotebookCellUpdateRequest(ModelNormal):
         """
         The description of a notebook cell update request.
 
-        :param attributes: The attributes of a notebook cell in update cell request. Valid cell types are ``markdown``\ , ``timeseries``\ , ``toplist``\ , ``heatmap``\ , ``distribution``\ ,
+        :param attributes: The attributes of a notebook cell in update cell request. Valid cell types are ``markdown`` , ``timeseries`` , ``toplist`` , ``heatmap`` , ``distribution`` ,
             ``log_stream``. `More information on each graph visualization type. <https://docs.datadoghq.com/dashboards/widgets/>`_
         :type attributes: NotebookCellUpdateRequestAttributes
 

--- a/src/datadog_api_client/v1/model/notebook_cell_update_request_attributes.py
+++ b/src/datadog_api_client/v1/model/notebook_cell_update_request_attributes.py
@@ -28,7 +28,7 @@ def lazy_import():
 class NotebookCellUpdateRequestAttributes(ModelComposed):
     def __init__(self, *args, **kwargs):
         """
-        The attributes of a notebook cell in update cell request. Valid cell types are ``markdown``\ , ``timeseries``\ , ``toplist``\ , ``heatmap``\ , ``distribution``\ ,
+        The attributes of a notebook cell in update cell request. Valid cell types are ``markdown`` , ``timeseries`` , ``toplist`` , ``heatmap`` , ``distribution`` ,
         ``log_stream``. `More information on each graph visualization type. <https://docs.datadoghq.com/dashboards/widgets/>`_
 
         :param definition: Text in a notebook is formatted with [Markdown](https://daringfireball.net/projects/markdown/), which enables the use of headings, subheadings, links, images, lists, and code blocks.

--- a/src/datadog_api_client/v1/model/notebook_markdown_cell_attributes.py
+++ b/src/datadog_api_client/v1/model/notebook_markdown_cell_attributes.py
@@ -31,7 +31,7 @@ class NotebookMarkdownCellAttributes(ModelNormal):
         """
         The attributes of a notebook ``markdown`` cell.
 
-        :param definition: Text in a notebook is formatted with `Markdown <https://daringfireball.net/projects/markdown/>`_\ , which enables the use of headings, subheadings, links, images, lists, and code blocks.
+        :param definition: Text in a notebook is formatted with `Markdown <https://daringfireball.net/projects/markdown/>`_ , which enables the use of headings, subheadings, links, images, lists, and code blocks.
         :type definition: NotebookMarkdownCellDefinition
         """
         super().__init__(kwargs)

--- a/src/datadog_api_client/v1/model/notebook_markdown_cell_definition.py
+++ b/src/datadog_api_client/v1/model/notebook_markdown_cell_definition.py
@@ -31,7 +31,7 @@ class NotebookMarkdownCellDefinition(ModelNormal):
 
     def __init__(self, text, type, *args, **kwargs):
         """
-        Text in a notebook is formatted with `Markdown <https://daringfireball.net/projects/markdown/>`_\ , which enables the use of headings, subheadings, links, images, lists, and code blocks.
+        Text in a notebook is formatted with `Markdown <https://daringfireball.net/projects/markdown/>`_ , which enables the use of headings, subheadings, links, images, lists, and code blocks.
 
         :param text: The markdown content.
         :type text: str

--- a/src/datadog_api_client/v1/model/organization_settings.py
+++ b/src/datadog_api_client/v1/model/organization_settings.py
@@ -71,7 +71,7 @@ class OrganizationSettings(ModelNormal):
         :param saml_autocreate_access_role: The access role of the user. Options are **st** (standard user), **adm** (admin user), or **ro** (read-only user).
         :type saml_autocreate_access_role: AccessRole, optional
 
-        :param saml_autocreate_users_domains: Has two properties, ``enabled`` (boolean) and ``domains``\ , which is a list of domains without the @ symbol.
+        :param saml_autocreate_users_domains: Has two properties, ``enabled`` (boolean) and ``domains`` , which is a list of domains without the @ symbol.
         :type saml_autocreate_users_domains: OrganizationSettingsSamlAutocreateUsersDomains, optional
 
         :param saml_can_be_enabled: Whether or not SAML can be enabled for this organization.

--- a/src/datadog_api_client/v1/model/organization_settings_saml_autocreate_users_domains.py
+++ b/src/datadog_api_client/v1/model/organization_settings_saml_autocreate_users_domains.py
@@ -24,7 +24,7 @@ class OrganizationSettingsSamlAutocreateUsersDomains(ModelNormal):
 
     def __init__(self, *args, **kwargs):
         """
-        Has two properties, ``enabled`` (boolean) and ``domains``\ , which is a list of domains without the @ symbol.
+        Has two properties, ``enabled`` (boolean) and ``domains`` , which is a list of domains without the @ symbol.
 
         :param domains: List of domains where the SAML automated user creation is enabled.
         :type domains: [str], optional

--- a/src/datadog_api_client/v1/model/organization_subscription.py
+++ b/src/datadog_api_client/v1/model/organization_subscription.py
@@ -24,7 +24,7 @@ class OrganizationSubscription(ModelNormal):
         """
         Subscription definition.
 
-        :param type: The subscription type. Types available are ``trial``\ , ``free``\ , and ``pro``.
+        :param type: The subscription type. Types available are ``trial`` , ``free`` , and ``pro``.
         :type type: str, optional
         """
         super().__init__(kwargs)

--- a/src/datadog_api_client/v1/model/series.py
+++ b/src/datadog_api_client/v1/model/series.py
@@ -58,7 +58,7 @@ class Series(ModelNormal):
         :param tags: A list of tags associated with the metric.
         :type tags: [str], optional
 
-        :param type: The type of the metric. Valid types are "",\ ``count``\ , ``gauge``\ , and ``rate``.
+        :param type: The type of the metric. Valid types are "", ``count`` , ``gauge`` , and ``rate``.
         :type type: str, optional
         """
         super().__init__(kwargs)

--- a/src/datadog_api_client/v1/model/service_level_objective.py
+++ b/src/datadog_api_client/v1/model/service_level_objective.py
@@ -67,7 +67,7 @@ class ServiceLevelObjective(ModelNormal):
     def __init__(self, name, thresholds, type, *args, **kwargs):
         """
         A service level objective object includes a service level indicator, thresholds
-        for one or more timeframes, and metadata (\ ``name``\ , ``description``\ , ``tags``\ , etc.).
+        for one or more timeframes, and metadata ( ``name`` , ``description`` , ``tags`` , etc.).
 
         :param created_at: Creation timestamp (UNIX time in seconds)
 
@@ -79,7 +79,7 @@ class ServiceLevelObjective(ModelNormal):
 
         :param description: A user-defined description of the service level objective.
 
-            Always included in service level objective responses (but may be ``null``\ ).
+            Always included in service level objective responses (but may be ``null`` ).
             Optional in create/update requests.
         :type description: str, none_type, optional
 

--- a/src/datadog_api_client/v1/model/service_level_objective_request.py
+++ b/src/datadog_api_client/v1/model/service_level_objective_request.py
@@ -49,11 +49,11 @@ class ServiceLevelObjectiveRequest(ModelNormal):
     def __init__(self, name, thresholds, type, *args, **kwargs):
         """
         A service level objective object includes a service level indicator, thresholds
-        for one or more timeframes, and metadata (\ ``name``\ , ``description``\ , ``tags``\ , etc.).
+        for one or more timeframes, and metadata ( ``name`` , ``description`` , ``tags`` , etc.).
 
         :param description: A user-defined description of the service level objective.
 
-            Always included in service level objective responses (but may be ``null``\ ).
+            Always included in service level objective responses (but may be ``null`` ).
             Optional in create/update requests.
         :type description: str, none_type, optional
 

--- a/src/datadog_api_client/v1/model/slo_correction_create_request_attributes.py
+++ b/src/datadog_api_client/v1/model/slo_correction_create_request_attributes.py
@@ -58,7 +58,7 @@ class SLOCorrectionCreateRequestAttributes(ModelNormal):
         :type end: int, optional
 
         :param rrule: The recurrence rules as defined in the iCalendar RFC 5545. The supported rules for SLO corrections
-            are ``FREQ``\ , ``INTERVAL``\ , ``COUNT`` and ``UNTIL``.
+            are ``FREQ`` , ``INTERVAL`` , ``COUNT`` and ``UNTIL``.
         :type rrule: str, optional
 
         :param slo_id: ID of the SLO that this correction applies to.

--- a/src/datadog_api_client/v1/model/slo_correction_response_attributes.py
+++ b/src/datadog_api_client/v1/model/slo_correction_response_attributes.py
@@ -88,7 +88,7 @@ class SLOCorrectionResponseAttributes(ModelNormal):
         :type modifier: SLOCorrectionResponseAttributesModifier, none_type, optional
 
         :param rrule: The recurrence rules as defined in the iCalendar RFC 5545. The supported rules for SLO corrections
-            are ``FREQ``\ , ``INTERVAL``\ , ``COUNT``\ , and ``UNTIL``.
+            are ``FREQ`` , ``INTERVAL`` , ``COUNT`` , and ``UNTIL``.
         :type rrule: str, none_type, optional
 
         :param slo_id: ID of the SLO that this correction applies to.

--- a/src/datadog_api_client/v1/model/slo_correction_update_request_attributes.py
+++ b/src/datadog_api_client/v1/model/slo_correction_update_request_attributes.py
@@ -56,7 +56,7 @@ class SLOCorrectionUpdateRequestAttributes(ModelNormal):
         :type end: int, optional
 
         :param rrule: The recurrence rules as defined in the iCalendar RFC 5545. The supported rules for SLO corrections
-            are ``FREQ``\ , ``INTERVAL``\ , ``COUNT``\ , and ``UNTIL``.
+            are ``FREQ`` , ``INTERVAL`` , ``COUNT`` , and ``UNTIL``.
         :type rrule: str, optional
 
         :param start: Starting time of the correction in epoch seconds.

--- a/src/datadog_api_client/v1/model/slo_history_metrics_series_metadata_unit.py
+++ b/src/datadog_api_client/v1/model/slo_history_metrics_series_metadata_unit.py
@@ -37,7 +37,7 @@ class SLOHistoryMetricsSeriesMetadataUnit(ModelNormal):
         """
         An Object of metric units.
 
-        :param family: The family of metric unit, for example ``bytes`` is the family for ``kibibyte``\ , ``byte``\ , and ``bit`` units.
+        :param family: The family of metric unit, for example ``bytes`` is the family for ``kibibyte`` , ``byte`` , and ``bit`` units.
         :type family: str, optional
 
         :param id: The ID of the metric unit.

--- a/src/datadog_api_client/v1/model/slo_history_response_data.py
+++ b/src/datadog_api_client/v1/model/slo_history_response_data.py
@@ -95,7 +95,7 @@ class SLOHistoryResponseData(ModelNormal):
         :param type: The type of the service level objective.
         :type type: SLOType, optional
 
-        :param type_id: A numeric representation of the type of the service level objective (\ ``0`` for
+        :param type_id: A numeric representation of the type of the service level objective ( ``0`` for
             monitor, ``1`` for metric). Always included in service level objective responses.
             Ignored in create/update requests.
         :type type_id: SLOTypeNumeric, optional

--- a/src/datadog_api_client/v1/model/slo_response.py
+++ b/src/datadog_api_client/v1/model/slo_response.py
@@ -34,7 +34,7 @@ class SLOResponse(ModelNormal):
         A service level objective response containing a single service level objective.
 
         :param data: A service level objective object includes a service level indicator, thresholds
-            for one or more timeframes, and metadata (\ ``name``\ , ``description``\ , ``tags``\ , etc.).
+            for one or more timeframes, and metadata ( ``name`` , ``description`` , ``tags`` , etc.).
         :type data: SLOResponseData, optional
 
         :param errors: An array of error messages. Each endpoint documents how/whether this field is

--- a/src/datadog_api_client/v1/model/slo_response_data.py
+++ b/src/datadog_api_client/v1/model/slo_response_data.py
@@ -69,7 +69,7 @@ class SLOResponseData(ModelNormal):
     def __init__(self, *args, **kwargs):
         """
         A service level objective object includes a service level indicator, thresholds
-        for one or more timeframes, and metadata (\ ``name``\ , ``description``\ , ``tags``\ , etc.).
+        for one or more timeframes, and metadata ( ``name`` , ``description`` , ``tags`` , etc.).
 
         :param configured_alert_ids: A list of SLO monitors IDs that reference this SLO. This field is returned only when ``with_configured_alert_ids`` parameter is true in query.
         :type configured_alert_ids: [int], optional
@@ -84,7 +84,7 @@ class SLOResponseData(ModelNormal):
 
         :param description: A user-defined description of the service level objective.
 
-            Always included in service level objective responses (but may be ``null``\ ).
+            Always included in service level objective responses (but may be ``null`` ).
             Optional in create/update requests.
         :type description: str, none_type, optional
 

--- a/src/datadog_api_client/v1/model/slo_threshold.py
+++ b/src/datadog_api_client/v1/model/slo_threshold.py
@@ -44,7 +44,7 @@ class SLOThreshold(ModelNormal):
         :type target: float
 
         :param target_display: A string representation of the target that indicates its precision.
-            It uses trailing zeros to show significant decimal places (for example ``98.00``\ ).
+            It uses trailing zeros to show significant decimal places (for example ``98.00`` ).
 
             Always included in service level objective responses. Ignored in
             create/update requests.

--- a/src/datadog_api_client/v1/model/synthetics_api_test.py
+++ b/src/datadog_api_client/v1/model/synthetics_api_test.py
@@ -84,12 +84,12 @@ class SyntheticsAPITest(ModelNormal):
         :param public_id: The public ID for the test.
         :type public_id: str, optional
 
-        :param status: Define whether you want to start (\ ``live``\ ) or pause (\ ``paused``\ ) a
+        :param status: Define whether you want to start ( ``live`` ) or pause ( ``paused`` ) a
             Synthetic test.
         :type status: SyntheticsTestPauseStatus, optional
 
-        :param subtype: The subtype of the Synthetic API test, ``http``\ , ``ssl``\ , ``tcp``\ ,
-            ``dns``\ , ``icmp``\ , ``udp``\ , ``websocket``\ , ``grpc`` or ``multi``.
+        :param subtype: The subtype of the Synthetic API test, ``http`` , ``ssl`` , ``tcp`` ,
+            ``dns`` , ``icmp`` , ``udp`` , ``websocket`` , ``grpc`` or ``multi``.
         :type subtype: SyntheticsTestDetailsSubType, optional
 
         :param tags: Array of tags attached to the test.

--- a/src/datadog_api_client/v1/model/synthetics_api_test_config.py
+++ b/src/datadog_api_client/v1/model/synthetics_api_test_config.py
@@ -52,7 +52,7 @@ class SyntheticsAPITestConfig(ModelNormal):
         :param request: Object describing the Synthetic test request.
         :type request: SyntheticsTestRequest, optional
 
-        :param steps: When the test subtype is ``multi``\ , the steps of the test.
+        :param steps: When the test subtype is ``multi`` , the steps of the test.
         :type steps: [SyntheticsAPIStep], optional
         """
         super().__init__(kwargs)

--- a/src/datadog_api_client/v1/model/synthetics_browser_test.py
+++ b/src/datadog_api_client/v1/model/synthetics_browser_test.py
@@ -84,7 +84,7 @@ class SyntheticsBrowserTest(ModelNormal):
         :param public_id: The public ID of the test.
         :type public_id: str, optional
 
-        :param status: Define whether you want to start (\ ``live``\ ) or pause (\ ``paused``\ ) a
+        :param status: Define whether you want to start ( ``live`` ) or pause ( ``paused`` ) a
             Synthetic test.
         :type status: SyntheticsTestPauseStatus, optional
 

--- a/src/datadog_api_client/v1/model/synthetics_global_variable_parse_test_options.py
+++ b/src/datadog_api_client/v1/model/synthetics_global_variable_parse_test_options.py
@@ -39,7 +39,7 @@ class SyntheticsGlobalVariableParseTestOptions(ModelNormal):
         """
         Parser options to use for retrieving a Synthetics global variable from a Synthetics Test. Used in conjunction with ``parse_test_public_id``.
 
-        :param field: When type is ``http_header``\ , name of the header to use to extract the value.
+        :param field: When type is ``http_header`` , name of the header to use to extract the value.
         :type field: str, optional
 
         :param parser: Details of the parser to use for the global variable.

--- a/src/datadog_api_client/v1/model/synthetics_parsing_options.py
+++ b/src/datadog_api_client/v1/model/synthetics_parsing_options.py
@@ -41,7 +41,7 @@ class SyntheticsParsingOptions(ModelNormal):
         """
         Parsing options for variables to extract.
 
-        :param field: When type is ``http_header``\ , name of the header to use to extract the value.
+        :param field: When type is ``http_header`` , name of the header to use to extract the value.
         :type field: str, optional
 
         :param name: Name of the variable to extract.

--- a/src/datadog_api_client/v1/model/synthetics_test_details.py
+++ b/src/datadog_api_client/v1/model/synthetics_test_details.py
@@ -96,15 +96,15 @@ class SyntheticsTestDetails(ModelNormal):
         :param public_id: The test public ID.
         :type public_id: str, optional
 
-        :param status: Define whether you want to start (\ ``live``\ ) or pause (\ ``paused``\ ) a
+        :param status: Define whether you want to start ( ``live`` ) or pause ( ``paused`` ) a
             Synthetic test.
         :type status: SyntheticsTestPauseStatus, optional
 
         :param steps: For browser test, the steps of the test.
         :type steps: [SyntheticsStep], optional
 
-        :param subtype: The subtype of the Synthetic API test, ``http``\ , ``ssl``\ , ``tcp``\ ,
-            ``dns``\ , ``icmp``\ , ``udp``\ , ``websocket``\ , ``grpc`` or ``multi``.
+        :param subtype: The subtype of the Synthetic API test, ``http`` , ``ssl`` , ``tcp`` ,
+            ``dns`` , ``icmp`` , ``udp`` , ``websocket`` , ``grpc`` or ``multi``.
         :type subtype: SyntheticsTestDetailsSubType, optional
 
         :param tags: Array of tags attached to the test.

--- a/src/datadog_api_client/v1/model/synthetics_update_test_pause_status_payload.py
+++ b/src/datadog_api_client/v1/model/synthetics_update_test_pause_status_payload.py
@@ -31,7 +31,7 @@ class SyntheticsUpdateTestPauseStatusPayload(ModelNormal):
         """
         Object to start or pause an existing Synthetic test.
 
-        :param new_status: Define whether you want to start (\ ``live``\ ) or pause (\ ``paused``\ ) a
+        :param new_status: Define whether you want to start ( ``live`` ) or pause ( ``paused`` ) a
             Synthetic test.
         :type new_status: SyntheticsTestPauseStatus, optional
         """

--- a/src/datadog_api_client/v1/model/usage_host_hour.py
+++ b/src/datadog_api_client/v1/model/usage_host_hour.py
@@ -89,7 +89,7 @@ class UsageHostHour(ModelNormal):
         :type heroku_host_count: int, optional
 
         :param host_count: Contains the total number of billable infrastructure hosts reporting during a given hour.
-            This is the sum of ``agent_host_count``\ , ``aws_host_count``\ , and ``gcp_host_count``.
+            This is the sum of ``agent_host_count`` , ``aws_host_count`` , and ``gcp_host_count``.
         :type host_count: int, optional
 
         :param hour: The hour for the usage.

--- a/src/datadog_api_client/v1/model/webhooks_integration.py
+++ b/src/datadog_api_client/v1/model/webhooks_integration.py
@@ -40,7 +40,7 @@ class WebhooksIntegration(ModelNormal):
         """
         Datadog-Webhooks integration.
 
-        :param custom_headers: If ``null``\ , uses no header.
+        :param custom_headers: If ``null`` , uses no header.
             If given a JSON payload, these will be headers attached to your webhook.
         :type custom_headers: str, none_type, optional
 
@@ -52,7 +52,7 @@ class WebhooksIntegration(ModelNormal):
             `monitor notifications <https://docs.datadoghq.com/monitors/notify>`_.
         :type name: str
 
-        :param payload: If ``null``\ , uses the default payload.
+        :param payload: If ``null`` , uses the default payload.
             If given a JSON payload, the webhook returns the payload
             specified by the given payload.
             `Webhooks variable usage <https://docs.datadoghq.com/integrations/webhooks/#usage>`_.

--- a/src/datadog_api_client/v1/model/webhooks_integration_update_request.py
+++ b/src/datadog_api_client/v1/model/webhooks_integration_update_request.py
@@ -42,7 +42,7 @@ class WebhooksIntegrationUpdateRequest(ModelNormal):
 
         *All properties are optional.*
 
-        :param custom_headers: If ``null``\ , uses no header.
+        :param custom_headers: If ``null`` , uses no header.
             If given a JSON payload, these will be headers attached to your webhook.
         :type custom_headers: str, optional
 
@@ -54,7 +54,7 @@ class WebhooksIntegrationUpdateRequest(ModelNormal):
             `monitor notifications <https://docs.datadoghq.com/monitors/notify>`_.
         :type name: str, optional
 
-        :param payload: If ``null``\ , uses the default payload.
+        :param payload: If ``null`` , uses the default payload.
             If given a JSON payload, the webhook returns the payload
             specified by the given payload.
             `Webhooks variable usage <https://docs.datadoghq.com/integrations/webhooks/#usage>`_.

--- a/src/datadog_api_client/v1/model/widget.py
+++ b/src/datadog_api_client/v1/model/widget.py
@@ -37,8 +37,8 @@ class Widget(ModelNormal):
         """
         Information about widget.
 
-        **Note**\ : The ``layout`` property is required for widgets in dashboards with ``free`` ``layout_type``.
-              For the **new dashboard layout**\ , the ``layout`` property depends on the ``reflow_type`` of the dashboard.
+        **Note** : The ``layout`` property is required for widgets in dashboards with ``free`` ``layout_type``.
+              For the **new dashboard layout** , the ``layout`` property depends on the ``reflow_type`` of the dashboard.
 
         .. code-block::
 

--- a/src/datadog_api_client/v1/model/widget_axis.py
+++ b/src/datadog_api_client/v1/model/widget_axis.py
@@ -44,7 +44,7 @@ class WidgetAxis(ModelNormal):
         :param min: Specifies minimum value to show on the y-axis. It takes a number, or auto for default behavior.
         :type min: str, optional
 
-        :param scale: Specifies the scale type. Possible values are ``linear``\ , ``log``\ , ``sqrt``\ , ``pow##`` (for example ``pow2``\ , ``pow0.5`` etc.).
+        :param scale: Specifies the scale type. Possible values are ``linear`` , ``log`` , ``sqrt`` , ``pow##`` (for example ``pow2`` , ``pow0.5`` etc.).
         :type scale: str, optional
         """
         super().__init__(kwargs)

--- a/src/datadog_api_client/v1/model/widget_custom_link.py
+++ b/src/datadog_api_client/v1/model/widget_custom_link.py
@@ -39,7 +39,7 @@ class WidgetCustomLink(ModelNormal):
         :param link: The URL of the custom link. URL must include ``http`` or ``https``. A relative URL must start with ``/``.
         :type link: str, optional
 
-        :param override_label: The label ID that refers to a context menu link. Can be ``logs``\ , ``hosts``\ , ``traces``\ , ``profiles``\ , ``processes``\ , ``containers``\ , or ``rum``.
+        :param override_label: The label ID that refers to a context menu link. Can be ``logs`` , ``hosts`` , ``traces`` , ``profiles`` , ``processes`` , ``containers`` , or ``rum``.
         :type override_label: str, optional
         """
         super().__init__(kwargs)

--- a/src/datadog_api_client/v1/model/widget_layout.py
+++ b/src/datadog_api_client/v1/model/widget_layout.py
@@ -51,7 +51,7 @@ class WidgetLayout(ModelNormal):
         :type height: int
 
         :param is_column_break: Whether the widget should be the first one on the second column in high density or not.
-            **Note**\ : Only for the **new dashboard layout** and only one widget in the dashboard should have this property set to ``true``.
+            **Note** : Only for the **new dashboard layout** and only one widget in the dashboard should have this property set to ``true``.
         :type is_column_break: bool, optional
 
         :param width: The width of the widget. Should be a non-negative integer.

--- a/src/datadog_api_client/v2/api/logs_api.py
+++ b/src/datadog_api_client/v2/api/logs_api.py
@@ -259,9 +259,9 @@ class LogsApi:
 
         Use this endpoint to build complex logs filtering and search.
 
-        **If you are considering archiving logs for your organization,
+        If you are considering archiving logs for your organization,
         consider use of the Datadog archive capabilities instead of the log list API.
-        See `Datadog Logs Archive documentation <https://docs.datadoghq.com/logs/archives>`_.**
+        See `Datadog Logs Archive documentation <https://docs.datadoghq.com/logs/archives>`_.
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True.
@@ -344,9 +344,9 @@ class LogsApi:
 
         Use this endpoint to see your latest logs.
 
-        **If you are considering archiving logs for your organization,
+        If you are considering archiving logs for your organization,
         consider use of the Datadog archive capabilities instead of the log list API.
-        See `Datadog Logs Archive documentation <https://docs.datadoghq.com/logs/archives>`_.**
+        See `Datadog Logs Archive documentation <https://docs.datadoghq.com/logs/archives>`_.
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True.

--- a/src/datadog_api_client/v2/api/logs_archives_api.py
+++ b/src/datadog_api_client/v2/api/logs_archives_api.py
@@ -262,7 +262,7 @@ class LogsArchivesApi:
     def add_read_role_to_archive(self, archive_id, body, **kwargs):
         """Grant role to an archive.
 
-        Adds a read role to an archive. (\ `Roles API <https://docs.datadoghq.com/api/v2/roles/>`_\ )
+        Adds a read role to an archive. ( `Roles API <https://docs.datadoghq.com/api/v2/roles/>`_ )
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True.
@@ -566,7 +566,7 @@ class LogsArchivesApi:
     def remove_role_from_archive(self, archive_id, body, **kwargs):
         """Revoke role from an archive.
 
-        Removes a role from an archive. (\ `Roles API <https://docs.datadoghq.com/api/v2/roles/>`_\ )
+        Removes a role from an archive. ( `Roles API <https://docs.datadoghq.com/api/v2/roles/>`_ )
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True.
@@ -615,7 +615,7 @@ class LogsArchivesApi:
 
         Update a given archive configuration.
 
-        **Note**\ : Using this method updates your archive configuration by **replacing**
+        **Note** : Using this method updates your archive configuration by **replacing**
         your current configuration with the new one sent to your Datadog organization.
 
         This method makes a synchronous HTTP request by default. To make an
@@ -667,7 +667,7 @@ class LogsArchivesApi:
         Update the order of your archives. Since logs are processed sequentially, reordering an archive may change
         the structure and content of the data processed by other archives.
 
-        **Note**\ : Using the ``PUT`` method updates your archive's order by replacing the current order
+        **Note** : Using the ``PUT`` method updates your archive's order by replacing the current order
         with the new one.
 
         This method makes a synchronous HTTP request by default. To make an

--- a/src/datadog_api_client/v2/api/metrics_api.py
+++ b/src/datadog_api_client/v2/api/metrics_api.py
@@ -32,7 +32,7 @@ class MetricsApi:
     * Modify tag configurations for metrics
     * View tags and volumes for metrics
 
-    **Note**\ : A graph can only contain a set number of points
+    **Note** : A graph can only contain a set number of points
     and as the timeframe over which a metric is viewed increases,
     aggregation between points occurs to stay below that set number.
 
@@ -572,7 +572,7 @@ class MetricsApi:
         :type filter_groups: str, optional
         :param filter_hours_ago: The number of hours of look back (from now) to estimate cardinality with.
         :type filter_hours_ago: int, optional
-        :param filter_num_aggregations: The number of aggregations that a ``count``\ , ``rate``\ , or ``gauge`` metric is configured to use. Max number of aggregation combos is 9.
+        :param filter_num_aggregations: The number of aggregations that a ``count`` , ``rate`` , or ``gauge`` metric is configured to use. Max number of aggregation combos is 9.
         :type filter_num_aggregations: int, optional
         :param filter_pct: A boolean, for distribution metrics only, to estimate cardinality if the metric includes additional percentile aggregators.
         :type filter_pct: bool, optional

--- a/src/datadog_api_client/v2/api/roles_api.py
+++ b/src/datadog_api_client/v2/api/roles_api.py
@@ -820,7 +820,7 @@ class RolesApi:
         :type page_number: int, optional
         :param sort: User attribute to order results by. Sort order is **ascending** by default.
             Sort order is **descending** if the field is prefixed by a negative sign,
-            for example ``sort=-name``. Options: ``name``\ , ``email``\ , ``status``.
+            for example ``sort=-name``. Options: ``name`` , ``email`` , ``status``.
         :type sort: str, optional
         :param filter: Filter all users by the given string. Defaults to no filtering.
         :type filter: str, optional

--- a/src/datadog_api_client/v2/api/security_monitoring_api.py
+++ b/src/datadog_api_client/v2/api/security_monitoring_api.py
@@ -935,7 +935,7 @@ class SecurityMonitoringApi:
     def update_security_monitoring_rule(self, rule_id, body, **kwargs):
         """Update an existing rule.
 
-        Update an existing rule. When updating ``cases``\ , ``queries`` or ``options``\ , the whole field
+        Update an existing rule. When updating ``cases`` , ``queries`` or ``options`` , the whole field
         must be included. For example, when modifying a query all queries must be included.
         Default rules can only be updated to be enabled and to change notifications.
 

--- a/src/datadog_api_client/v2/api/usage_metering_api.py
+++ b/src/datadog_api_client/v2/api/usage_metering_api.py
@@ -22,7 +22,7 @@ class UsageMeteringApi:
     This API is available to all Pro and Enterprise customers.
     Usage is only accessible for `parent-level organizations <https://docs.datadoghq.com/account_management/multi_organization/>`_.
 
-    **Note**\ : Usage data is delayed by up to 72 hours from when it was incurred.
+    **Note** : Usage data is delayed by up to 72 hours from when it was incurred.
     It is retained for 15 months.
 
     You can retrieve up to 24 hours of hourly usage data for multiple organizations,

--- a/src/datadog_api_client/v2/api/users_api.py
+++ b/src/datadog_api_client/v2/api/users_api.py
@@ -617,15 +617,15 @@ class UsersApi:
         :type page_number: int, optional
         :param sort: User attribute to order results by. Sort order is ascending by default.
             Sort order is descending if the field
-            is prefixed by a negative sign, for example ``sort=-name``. Options: ``name``\ ,
-            ``modified_at``\ , ``user_count``.
+            is prefixed by a negative sign, for example ``sort=-name``. Options: ``name`` ,
+            ``modified_at`` , ``user_count``.
         :type sort: str, optional
-        :param sort_dir: Direction of sort. Options: ``asc``\ , ``desc``.
+        :param sort_dir: Direction of sort. Options: ``asc`` , ``desc``.
         :type sort_dir: QuerySortOrder, optional
         :param filter: Filter all users by the given string. Defaults to no filtering.
         :type filter: str, optional
         :param filter_status: Filter on status attribute.
-            Comma separated list, with possible values ``Active``\ , ``Pending``\ , and ``Disabled``.
+            Comma separated list, with possible values ``Active`` , ``Pending`` , and ``Disabled``.
             Defaults to no filtering.
         :type filter_status: str, optional
         :param _return_http_data_only: Response data without head status

--- a/src/datadog_api_client/v2/model/logs_aggregate_sort.py
+++ b/src/datadog_api_client/v2/model/logs_aggregate_sort.py
@@ -44,7 +44,7 @@ class LogsAggregateSort(ModelNormal):
         :param aggregation: An aggregation function
         :type aggregation: LogsAggregationFunction, optional
 
-        :param metric: The metric to sort by (only used for ``type=measure``\ )
+        :param metric: The metric to sort by (only used for ``type=measure`` )
         :type metric: str, optional
 
         :param order: The order to use, ascending or descending

--- a/src/datadog_api_client/v2/model/metric_custom_aggregations.py
+++ b/src/datadog_api_client/v2/model/metric_custom_aggregations.py
@@ -42,7 +42,7 @@ class MetricCustomAggregations(ModelSimple):
         * time: sum, space: avg
         * time: sum, space: sum
 
-        Can only be applied to metrics that have a ``metric_type`` of ``count``\ , ``rate``\ , or ``gauge``.
+        Can only be applied to metrics that have a ``metric_type`` of ``count`` , ``rate`` , or ``gauge``.
 
         Note that value can be passed either in args or in kwargs, but not in both.
 

--- a/src/datadog_api_client/v2/model/metric_tag_configuration_attributes.py
+++ b/src/datadog_api_client/v2/model/metric_tag_configuration_attributes.py
@@ -60,7 +60,7 @@ class MetricTagConfigurationAttributes(ModelNormal):
             * time: sum, space: avg
             * time: sum, space: sum
 
-            Can only be applied to metrics that have a ``metric_type`` of ``count``\ , ``rate``\ , or ``gauge``.
+            Can only be applied to metrics that have a ``metric_type`` of ``count`` , ``rate`` , or ``gauge``.
         :type aggregations: MetricCustomAggregations, optional
 
         :param created_at: Timestamp when the tag configuration was created.

--- a/src/datadog_api_client/v2/model/metric_tag_configuration_create_attributes.py
+++ b/src/datadog_api_client/v2/model/metric_tag_configuration_create_attributes.py
@@ -55,7 +55,7 @@ class MetricTagConfigurationCreateAttributes(ModelNormal):
             * time: sum, space: avg
             * time: sum, space: sum
 
-            Can only be applied to metrics that have a ``metric_type`` of ``count``\ , ``rate``\ , or ``gauge``.
+            Can only be applied to metrics that have a ``metric_type`` of ``count`` , ``rate`` , or ``gauge``.
         :type aggregations: MetricCustomAggregations, optional
 
         :param include_percentiles: Toggle to include/exclude percentiles for a distribution metric.

--- a/src/datadog_api_client/v2/model/metric_tag_configuration_update_attributes.py
+++ b/src/datadog_api_client/v2/model/metric_tag_configuration_update_attributes.py
@@ -51,7 +51,7 @@ class MetricTagConfigurationUpdateAttributes(ModelNormal):
             * time: sum, space: avg
             * time: sum, space: sum
 
-            Can only be applied to metrics that have a ``metric_type`` of ``count``\ , ``rate``\ , or ``gauge``.
+            Can only be applied to metrics that have a ``metric_type`` of ``count`` , ``rate`` , or ``gauge``.
         :type aggregations: MetricCustomAggregations, optional
 
         :param include_percentiles: Toggle to include/exclude percentiles for a distribution metric.

--- a/src/datadog_api_client/v2/model/rum_aggregate_sort.py
+++ b/src/datadog_api_client/v2/model/rum_aggregate_sort.py
@@ -44,7 +44,7 @@ class RUMAggregateSort(ModelNormal):
         :param aggregation: An aggregation function.
         :type aggregation: RUMAggregationFunction, optional
 
-        :param metric: The metric to sort by (only used for ``type=measure``\ ).
+        :param metric: The metric to sort by (only used for ``type=measure`` ).
         :type metric: str, optional
 
         :param order: The order to use, ascending or descending.

--- a/src/datadog_api_client/v2/model/security_monitoring_rule_case.py
+++ b/src/datadog_api_client/v2/model/security_monitoring_rule_case.py
@@ -37,7 +37,7 @@ class SecurityMonitoringRuleCase(ModelNormal):
         """
         Case when signal is generated.
 
-        :param condition: A rule case contains logical operations (\ ``>``\ ,\ ``>=``\ , ``&&``\ , ``||``\ ) to determine if a signal should be generated
+        :param condition: A rule case contains logical operations ( ``>`` , ``>=`` , ``&&`` , ``||`` ) to determine if a signal should be generated
             based on the event counts in the previously defined queries.
         :type condition: str, optional
 

--- a/src/datadog_api_client/v2/model/security_monitoring_rule_case_create.py
+++ b/src/datadog_api_client/v2/model/security_monitoring_rule_case_create.py
@@ -37,7 +37,7 @@ class SecurityMonitoringRuleCaseCreate(ModelNormal):
         """
         Case when signal is generated.
 
-        :param condition: A rule case contains logical operations (\ ``>``\ ,\ ``>=``\ , ``&&``\ , ``||``\ ) to determine if a signal should be generated
+        :param condition: A rule case contains logical operations ( ``>`` , ``>=`` , ``&&`` , ``||`` ) to determine if a signal should be generated
             based on the event counts in the previously defined queries.
         :type condition: str, optional
 

--- a/src/datadog_api_client/v2/model/security_monitoring_signals_list_response_links.py
+++ b/src/datadog_api_client/v2/model/security_monitoring_signals_list_response_links.py
@@ -24,7 +24,7 @@ class SecurityMonitoringSignalsListResponseLinks(ModelNormal):
         """
         Links attributes.
 
-        :param next: The link for the next set of results. **Note**\ : The request can also be made using the
+        :param next: The link for the next set of results. **Note** : The request can also be made using the
             POST endpoint.
         :type next: str, optional
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,7 +164,7 @@ def pytest_bdd_apply_tag(tag, function):
     if tag in skip_tags:
         marker = pytest.mark.skip(reason=f"skipped because of '{tag} in {skip_tags}")
         marker(function)
-        return True
+    return True
 
 
 def snake_case(value):


### PR DESCRIPTION
Handle model ambiguity by linking the closes one in the import try (v1
apis references v1 models for examples), and remove links inside
emphasis.