### PR TITLE
tests: use upstream pytest-bdd traces

### DIFF
--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -59,9 +59,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install --upgrade wheel setuptools build
       - name: Install
-        run: |
-          pip install --disable-pip-version-check git+https://github.com/DataDog/dd-trace-py.git#egg=ddtrace
-          pip install --disable-pip-version-check -e .[tests]
+        run: pip install --disable-pip-version-check -e .[apm,tests]
       - name: Test
         run: ./run-tests.sh
         shell: bash

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ setup_requires =
 
 [options.extras_require]
 apm =
-    ddtrace>=1.0.0rc1
+    ddtrace>=1.2.0
 async =
     aiosonic
 zstandard =


### PR DESCRIPTION
- [ ] needs `ddtrace==1.2.0`

---

Trace
https://app.datadoghq.com/ci/test-commit/github.com%2FDataDog%2Fdatadog-api-client-python/datadog-api-client-python/jirikuncar%2FITL-788%2Fpytest-bdd/bd646a13d8d3ccaa3e4a896340b275bbe36a6c51?query=env%3Aprod%20%40git.repository.id%3A%22github.com%2FDataDog%2Fdatadog-api-client-python%22%20%40test.service%3Adatadog-api-client-python%20%40git.branch%3A%22jirikuncar%2FITL-788%2Fpytest-bdd%22%20%40git.commit.sha%3Abd646a13d8d3ccaa3e4a896340b275bbe36a6c51&currentTab=trace&env=prod&index=citest&spanID=2961140448467777036&trace=AQAAAYEkvBJIaqI2jwAAAABBWUVrdkJKSUFBQWZLaWZVWlVqNlZLTGY&start=1651586739987&end=1654178739987&paused=false