### PR TITLE
Add typing to API arguments

### DIFF
--- a/.generator/conftest.py
+++ b/.generator/conftest.py
@@ -187,7 +187,7 @@ def unique(request):
 TIME_FORMATTER = {
     "now": "datetime.now()",
     "timestamp": "{sret}.timestamp()",
-    "isoformat": '{sret}.isoformat(timespec="seconds")',
+    "isoformat": "{sret}",
     "units": {
         "s": "({sret} + relativedelta(seconds={num}))",
         "m": "({sret} + relativedelta(minutes={num}))",

--- a/.generator/src/generator/openapi.py
+++ b/.generator/src/generator/openapi.py
@@ -113,13 +113,19 @@ def get_type_for_items(schema):
     return name
 
 
-def get_type_for_parameter(parameter):
+def get_type_for_parameter(parameter, typing=False):
     """Return Python type name for the parameter."""
     if "content" in parameter:
         assert "in" not in parameter
         for content in parameter["content"].values():
-            return type_to_python(content["schema"])
-    return type_to_python(parameter.get("schema"))
+            data = type_to_python(content["schema"])
+            if typing:
+                data = data.replace("[", "List[")
+            return data
+    data = type_to_python(parameter.get("schema"))
+    if typing:
+        data = data.replace("[", "List[")
+    return data
 
 
 def get_enum_type(schema):

--- a/.generator/src/generator/templates/api.j2
+++ b/.generator/src/generator/templates/api.j2
@@ -1,5 +1,7 @@
 {% include "api_info.j2" %}
+from __future__ import annotations
 
+from typing import Any, Dict, List, Union
 
 from {{ package }}.api_client import ApiClient, Endpoint as _Endpoint
 from {{ package }}.model_utils import (
@@ -9,6 +11,8 @@ from {{ package }}.model_utils import (
     get_attribute_from_path,
     file_type,
     none_type,
+    UnsetType,
+    unset,
 )
 {%- for model in get_api_models(operations) %}
 from {{ package }}.{{ version }}.model.{{ model|safe_snake_case }} import {{ model }}
@@ -134,7 +138,8 @@ class {{ classname }}:
 {% endfor %}
 
 {%- for path, method, operation in operations|sort(attribute="2.operationId") %}
-    def {{ operation.operationId|safe_snake_case }}(self, {% for name, parameter in operation|parameters if parameter.required %}{{name|attribute_name}}, {% endfor %}**kwargs):
+{%- set returnType = operation|return_type %}
+    def {{ operation.operationId|safe_snake_case }}(self, {% for name, parameter in operation|parameters if parameter.required %}{{name|attribute_name}}: {{ get_type_for_parameter(parameter, typing=True) }}, {% endfor %}{% for name, parameter in operation|parameters if not parameter.required %}{% if loop.first %}*, {% endif %}{{name|attribute_name}}: Union[{{ get_type_for_parameter(parameter, typing=True) }}, UnsetType]=unset, {% endfor %}) -> {% if returnType %}{{ returnType.replace("[", "List[") }}{% else %}None{% endif %}:
         """{{ operation.summary|indent(8) }}.
 {% if operation.description %}
         {{ operation.description|docstring|indent(8) }}
@@ -153,8 +158,14 @@ class {{ classname }}:
 {%- set returnType = operation|return_type %}
         :rtype: {% if returnType %}{{ returnType }}{% else %}None{% endif %}
         """
-{%- for name, parameter in operation|parameters if parameter.required %}
+        kwargs: Dict[str, Any] = {}
+{%- for name, parameter in operation|parameters %}
+{%- if not parameter.required %}
+        if {{ name|attribute_name }} is not unset:
+            kwargs["{{ name|attribute_name }}"] = {{ name|attribute_name }}
+{%- else %}
         kwargs["{{ name|attribute_name }}"] = {{ name|attribute_name }}
+{%- endif %}
 {% endfor %}
         return self._{{ operation.operationId|safe_snake_case }}_endpoint.call_with_http_info(**kwargs)
     {%- if operation["x-pagination"] %}

--- a/.generator/src/generator/templates/model_utils.j2
+++ b/.generator/src/generator/templates/model_utils.j2
@@ -1,6 +1,7 @@
 {% include "api_info.j2" %}
 
 from datetime import date, datetime
+import enum
 import inspect
 import io
 import os
@@ -8,7 +9,7 @@ import pprint
 import re
 import tempfile
 from types import MappingProxyType
-from typing import Collection, Mapping, Union
+from typing import Collection, Final, Mapping, Union
 
 from dateutil.parser import parse
 
@@ -22,6 +23,12 @@ from {{ package }}.exceptions import (
 none_type = type(None)
 file_type = io.IOBase
 empty_dict = MappingProxyType({})  # type: ignore
+
+
+class UnsetType(enum.Enum):
+    unset = 0
+
+unset: Final = UnsetType.unset
 
 
 def convert_js_args_to_python_args(fn):

--- a/.generator/src/generator/templates/model_utils.j2
+++ b/.generator/src/generator/templates/model_utils.j2
@@ -9,7 +9,11 @@ import pprint
 import re
 import tempfile
 from types import MappingProxyType
-from typing import Collection, Final, Mapping, Union
+from typing import Collection, Mapping, Union
+try:
+    from typing import Final
+except ImportError:
+    from typing_extensions import Final
 
 from dateutil.parser import parse
 

--- a/.generator/src/generator/templates/model_utils.j2
+++ b/.generator/src/generator/templates/model_utils.j2
@@ -10,10 +10,7 @@ import re
 import tempfile
 from types import MappingProxyType
 from typing import Collection, Mapping, Union
-try:
-    from typing import Final
-except ImportError:
-    from typing_extensions import Final
+from typing_extensions import Final
 
 from dateutil.parser import parse
 

--- a/examples/v1/logs/ListLogs_235998668.py
+++ b/examples/v1/logs/ListLogs_235998668.py
@@ -15,9 +15,9 @@ body = LogsListRequest(
     query="host:Test*",
     sort=LogsSort("asc"),
     time=LogsListRequestTime(
-        _from=(datetime.now() + relativedelta(hours=-1)).isoformat(timespec="seconds"),
+        _from=(datetime.now() + relativedelta(hours=-1)),
         timezone="Europe/Paris",
-        to=datetime.now().isoformat(timespec="seconds"),
+        to=datetime.now(),
     ),
 )
 

--- a/examples/v1/usage-metering/GetHourlyUsageAttribution.py
+++ b/examples/v1/usage-metering/GetHourlyUsageAttribution.py
@@ -13,7 +13,7 @@ configuration.unstable_operations["get_hourly_usage_attribution"] = True
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_hourly_usage_attribution(
-        start_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-3)),
         usage_type=HourlyUsageAttributionUsageType("infra_host_usage"),
     )
 

--- a/examples/v1/usage-metering/GetIncidentManagement.py
+++ b/examples/v1/usage-metering/GetIncidentManagement.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_incident_management(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetIngestedSpans.py
+++ b/examples/v1/usage-metering/GetIngestedSpans.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_ingested_spans(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetMonthlyUsageAttribution.py
+++ b/examples/v1/usage-metering/GetMonthlyUsageAttribution.py
@@ -15,7 +15,7 @@ configuration.unstable_operations["get_monthly_usage_attribution"] = True
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_monthly_usage_attribution(
-        start_month=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_month=(datetime.now() + relativedelta(days=-3)),
         fields=MonthlyUsageAttributionSupportedMetrics("infra_host_usage"),
     )
 

--- a/examples/v1/usage-metering/GetMonthlyUsageAttribution_3849653599.py
+++ b/examples/v1/usage-metering/GetMonthlyUsageAttribution_3849653599.py
@@ -20,7 +20,7 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_monthly_usage_attribution(
-        start_month=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_month=(datetime.now() + relativedelta(days=-3)),
         fields=MonthlyUsageAttributionSupportedMetrics("infra_host_usage"),
         next_record_id=MONTHLY_USAGE_ATTRIBUTION_METADATA_PAGINATION_NEXT_RECORD_ID,
     )

--- a/examples/v1/usage-metering/GetUsageAnalyzedLogs.py
+++ b/examples/v1/usage-metering/GetUsageAnalyzedLogs.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_analyzed_logs(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageAttribution.py
+++ b/examples/v1/usage-metering/GetUsageAttribution.py
@@ -13,7 +13,7 @@ configuration.unstable_operations["get_usage_attribution"] = True
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_attribution(
-        start_month=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_month=(datetime.now() + relativedelta(days=-3)),
         fields=UsageAttributionSupportedMetrics("*"),
         offset=0,
         limit=1,

--- a/examples/v1/usage-metering/GetUsageAuditLogs.py
+++ b/examples/v1/usage-metering/GetUsageAuditLogs.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_audit_logs(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageCIApp.py
+++ b/examples/v1/usage-metering/GetUsageCIApp.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_ci_app(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageCWS.py
+++ b/examples/v1/usage-metering/GetUsageCWS.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_cws(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageCloudSecurityPostureManagement.py
+++ b/examples/v1/usage-metering/GetUsageCloudSecurityPostureManagement.py
@@ -11,7 +11,7 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_cloud_security_posture_management(
-        start_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageDBM.py
+++ b/examples/v1/usage-metering/GetUsageDBM.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_dbm(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageFargate.py
+++ b/examples/v1/usage-metering/GetUsageFargate.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_fargate(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageHosts.py
+++ b/examples/v1/usage-metering/GetUsageHosts.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_hosts(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageIndexedSpans.py
+++ b/examples/v1/usage-metering/GetUsageIndexedSpans.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_indexed_spans(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageInternetOfThings.py
+++ b/examples/v1/usage-metering/GetUsageInternetOfThings.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_internet_of_things(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageLambda.py
+++ b/examples/v1/usage-metering/GetUsageLambda.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_lambda(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageLogs.py
+++ b/examples/v1/usage-metering/GetUsageLogs.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_logs(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageLogsByIndex.py
+++ b/examples/v1/usage-metering/GetUsageLogsByIndex.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_logs_by_index(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageLogsByRetention.py
+++ b/examples/v1/usage-metering/GetUsageLogsByRetention.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_logs_by_retention(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageNetworkFlows.py
+++ b/examples/v1/usage-metering/GetUsageNetworkFlows.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_network_flows(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageNetworkHosts.py
+++ b/examples/v1/usage-metering/GetUsageNetworkHosts.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_network_hosts(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageOnlineArchive.py
+++ b/examples/v1/usage-metering/GetUsageOnlineArchive.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_online_archive(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageProfiling.py
+++ b/examples/v1/usage-metering/GetUsageProfiling.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_profiling(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageRumSessions.py
+++ b/examples/v1/usage-metering/GetUsageRumSessions.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_rum_sessions(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageRumSessions_3271366243.py
+++ b/examples/v1/usage-metering/GetUsageRumSessions_3271366243.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_rum_sessions(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
         type="mobile",
     )
 

--- a/examples/v1/usage-metering/GetUsageRumUnits.py
+++ b/examples/v1/usage-metering/GetUsageRumUnits.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_rum_units(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageSDS.py
+++ b/examples/v1/usage-metering/GetUsageSDS.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_sds(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageSNMP.py
+++ b/examples/v1/usage-metering/GetUsageSNMP.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_snmp(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageSyntheticsAPI.py
+++ b/examples/v1/usage-metering/GetUsageSyntheticsAPI.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_synthetics_api(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageSyntheticsBrowser.py
+++ b/examples/v1/usage-metering/GetUsageSyntheticsBrowser.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_synthetics_browser(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageTimeseries.py
+++ b/examples/v1/usage-metering/GetUsageTimeseries.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_timeseries(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v1/usage-metering/GetUsageTopAvgMetrics.py
+++ b/examples/v1/usage-metering/GetUsageTopAvgMetrics.py
@@ -11,7 +11,7 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_top_avg_metrics(
-        day=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        day=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v2/usage-metering/GetCostByOrg.py
+++ b/examples/v2/usage-metering/GetCostByOrg.py
@@ -11,7 +11,7 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_cost_by_org(
-        start_month=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_month=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v2/usage-metering/GetEstimatedCostByOrg_1171921972.py
+++ b/examples/v2/usage-metering/GetEstimatedCostByOrg_1171921972.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_estimated_cost_by_org(
-        start_month=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_month=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_month=(datetime.now() + relativedelta(days=-5)),
+        end_month=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v2/usage-metering/GetEstimatedCostByOrg_627383212.py
+++ b/examples/v2/usage-metering/GetEstimatedCostByOrg_627383212.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_estimated_cost_by_org(
-        start_date=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_date=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_date=(datetime.now() + relativedelta(days=-5)),
+        end_date=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v2/usage-metering/GetUsageApplicationSecurityMonitoring.py
+++ b/examples/v2/usage-metering/GetUsageApplicationSecurityMonitoring.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_application_security_monitoring(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v2/usage-metering/GetUsageLambdaTracedInvocations.py
+++ b/examples/v2/usage-metering/GetUsageLambdaTracedInvocations.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_lambda_traced_invocations(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/examples/v2/usage-metering/GetUsageObservabilityPipelines.py
+++ b/examples/v2/usage-metering/GetUsageObservabilityPipelines.py
@@ -11,8 +11,8 @@ configuration = Configuration()
 with ApiClient(configuration) as api_client:
     api_instance = UsageMeteringApi(api_client)
     response = api_instance.get_usage_observability_pipelines(
-        start_hr=(datetime.now() + relativedelta(days=-5)).isoformat(timespec="seconds"),
-        end_hr=(datetime.now() + relativedelta(days=-3)).isoformat(timespec="seconds"),
+        start_hr=(datetime.now() + relativedelta(days=-5)),
+        end_hr=(datetime.now() + relativedelta(days=-3)),
     )
 
     print(response)

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     urllib3>=1.15
     certifi
     python-dateutil
-    typing-extensions;python_version<'3.8'
+    typing-extensions
 setup_requires =
     setuptools>=30.3.0
     setuptools_scm

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ install_requires =
     urllib3>=1.15
     certifi
     python-dateutil
+    typing-extensions;python_version<'3.8'
 setup_requires =
     setuptools>=30.3.0
     setuptools_scm

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,6 +71,9 @@ tests =
 exclude = tests
 where=src
 
+[options.package_data]
+datadog_api_client = py.typed
+
 [tool:pytest]
 # addopts = --black --cov=datadog_api_client --cov-config .coveragerc --cov-report=term-missing
 

--- a/src/datadog_api_client/model_utils.py
+++ b/src/datadog_api_client/model_utils.py
@@ -3,6 +3,7 @@
 # Copyright 2019-Present Datadog, Inc.
 
 from datetime import date, datetime
+import enum
 import inspect
 import io
 import os
@@ -10,7 +11,7 @@ import pprint
 import re
 import tempfile
 from types import MappingProxyType
-from typing import Collection, Mapping, Union
+from typing import Collection, Final, Mapping, Union
 
 from dateutil.parser import parse
 
@@ -24,6 +25,13 @@ from datadog_api_client.exceptions import (
 none_type = type(None)
 file_type = io.IOBase
 empty_dict = MappingProxyType({})  # type: ignore
+
+
+class UnsetType(enum.Enum):
+    unset = 0
+
+
+unset: Final = UnsetType.unset
 
 
 def convert_js_args_to_python_args(fn):

--- a/src/datadog_api_client/model_utils.py
+++ b/src/datadog_api_client/model_utils.py
@@ -11,7 +11,11 @@ import pprint
 import re
 import tempfile
 from types import MappingProxyType
-from typing import Collection, Final, Mapping, Union
+from typing import Collection, Mapping, Union
+try:
+    from typing import Final
+except ImportError:
+    from typing_extensions import Final
 
 from dateutil.parser import parse
 

--- a/src/datadog_api_client/model_utils.py
+++ b/src/datadog_api_client/model_utils.py
@@ -12,11 +12,7 @@ import re
 import tempfile
 from types import MappingProxyType
 from typing import Collection, Mapping, Union
-
-try:
-    from typing import Final
-except ImportError:
-    from typing_extensions import Final
+from typing_extensions import Final
 
 from dateutil.parser import parse
 

--- a/src/datadog_api_client/model_utils.py
+++ b/src/datadog_api_client/model_utils.py
@@ -12,6 +12,7 @@ import re
 import tempfile
 from types import MappingProxyType
 from typing import Collection, Mapping, Union
+
 try:
     from typing import Final
 except ImportError:

--- a/src/datadog_api_client/v1/api/authentication_api.py
+++ b/src/datadog_api_client/v1/api/authentication_api.py
@@ -1,7 +1,9 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.v1.model.authentication_validation_response import AuthenticationValidationResponse
@@ -43,11 +45,14 @@ class AuthenticationApi:
             api_client=api_client,
         )
 
-    def validate(self, **kwargs):
+    def validate(
+        self,
+    ) -> AuthenticationValidationResponse:
         """Validate API key.
 
         Check if the API key (not the APP key) is valid. If invalid, a 403 is returned.
 
         :rtype: AuthenticationValidationResponse
         """
+        kwargs: Dict[str, Any] = {}
         return self._validate_endpoint.call_with_http_info(**kwargs)

--- a/src/datadog_api_client/v1/api/aws_integration_api.py
+++ b/src/datadog_api_client/v1/api/aws_integration_api.py
@@ -1,9 +1,15 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, List, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
+from datadog_api_client.model_utils import (
+    UnsetType,
+    unset,
+)
 from datadog_api_client.v1.model.aws_account_delete_request import AWSAccountDeleteRequest
 from datadog_api_client.v1.model.aws_account_list_response import AWSAccountListResponse
 from datadog_api_client.v1.model.aws_account_create_response import AWSAccountCreateResponse
@@ -242,7 +248,10 @@ class AWSIntegrationApi:
             api_client=api_client,
         )
 
-    def create_aws_account(self, body, **kwargs):
+    def create_aws_account(
+        self,
+        body: AWSAccount,
+    ) -> AWSAccountCreateResponse:
         """Create an AWS integration.
 
         Create a Datadog-Amazon Web Services integration.
@@ -254,11 +263,15 @@ class AWSIntegrationApi:
         :type body: AWSAccount
         :rtype: AWSAccountCreateResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_aws_account_endpoint.call_with_http_info(**kwargs)
 
-    def create_aws_tag_filter(self, body, **kwargs):
+    def create_aws_tag_filter(
+        self,
+        body: AWSTagFilterCreateRequest,
+    ) -> dict:
         """Set an AWS tag filter.
 
         Set an AWS tag filter.
@@ -268,11 +281,15 @@ class AWSIntegrationApi:
         :type body: AWSTagFilterCreateRequest
         :rtype: dict
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_aws_tag_filter_endpoint.call_with_http_info(**kwargs)
 
-    def create_new_aws_external_id(self, body, **kwargs):
+    def create_new_aws_external_id(
+        self,
+        body: AWSAccount,
+    ) -> AWSAccountCreateResponse:
         """Generate a new external ID.
 
         Generate a new AWS external ID for a given AWS account ID and role name pair.
@@ -283,11 +300,15 @@ class AWSIntegrationApi:
         :type body: AWSAccount
         :rtype: AWSAccountCreateResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_new_aws_external_id_endpoint.call_with_http_info(**kwargs)
 
-    def delete_aws_account(self, body, **kwargs):
+    def delete_aws_account(
+        self,
+        body: AWSAccountDeleteRequest,
+    ) -> dict:
         """Delete an AWS integration.
 
         Delete a Datadog-AWS integration matching the specified ``account_id`` and ``role_name parameters``.
@@ -296,11 +317,15 @@ class AWSIntegrationApi:
         :type body: AWSAccountDeleteRequest
         :rtype: dict
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._delete_aws_account_endpoint.call_with_http_info(**kwargs)
 
-    def delete_aws_tag_filter(self, body, **kwargs):
+    def delete_aws_tag_filter(
+        self,
+        body: AWSTagFilterDeleteRequest,
+    ) -> dict:
         """Delete a tag filtering entry.
 
         Delete a tag filtering entry.
@@ -309,20 +334,30 @@ class AWSIntegrationApi:
         :type body: AWSTagFilterDeleteRequest
         :rtype: dict
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._delete_aws_tag_filter_endpoint.call_with_http_info(**kwargs)
 
-    def list_available_aws_namespaces(self, **kwargs):
+    def list_available_aws_namespaces(
+        self,
+    ) -> List[str]:
         """List namespace rules.
 
         List all namespace rules for a given Datadog-AWS integration. This endpoint takes no arguments.
 
         :rtype: [str]
         """
+        kwargs: Dict[str, Any] = {}
         return self._list_available_aws_namespaces_endpoint.call_with_http_info(**kwargs)
 
-    def list_aws_accounts(self, **kwargs):
+    def list_aws_accounts(
+        self,
+        *,
+        account_id: Union[str, UnsetType] = unset,
+        role_name: Union[str, UnsetType] = unset,
+        access_key_id: Union[str, UnsetType] = unset,
+    ) -> AWSAccountListResponse:
         """List all AWS integrations.
 
         List all Datadog-AWS integrations available in your Datadog organization.
@@ -335,9 +370,22 @@ class AWSIntegrationApi:
         :type access_key_id: str, optional
         :rtype: AWSAccountListResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if account_id is not unset:
+            kwargs["account_id"] = account_id
+
+        if role_name is not unset:
+            kwargs["role_name"] = role_name
+
+        if access_key_id is not unset:
+            kwargs["access_key_id"] = access_key_id
+
         return self._list_aws_accounts_endpoint.call_with_http_info(**kwargs)
 
-    def list_aws_tag_filters(self, account_id, **kwargs):
+    def list_aws_tag_filters(
+        self,
+        account_id: str,
+    ) -> AWSTagFilterListResponse:
         """Get all AWS tag filters.
 
         Get all AWS tag filters.
@@ -346,11 +394,19 @@ class AWSIntegrationApi:
         :type account_id: str
         :rtype: AWSTagFilterListResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["account_id"] = account_id
 
         return self._list_aws_tag_filters_endpoint.call_with_http_info(**kwargs)
 
-    def update_aws_account(self, body, **kwargs):
+    def update_aws_account(
+        self,
+        body: AWSAccount,
+        *,
+        account_id: Union[str, UnsetType] = unset,
+        role_name: Union[str, UnsetType] = unset,
+        access_key_id: Union[str, UnsetType] = unset,
+    ) -> dict:
         """Update an AWS integration.
 
         Update a Datadog-Amazon Web Services integration.
@@ -367,6 +423,16 @@ class AWSIntegrationApi:
         :type access_key_id: str, optional
         :rtype: dict
         """
+        kwargs: Dict[str, Any] = {}
+        if account_id is not unset:
+            kwargs["account_id"] = account_id
+
+        if role_name is not unset:
+            kwargs["role_name"] = role_name
+
+        if access_key_id is not unset:
+            kwargs["access_key_id"] = access_key_id
+
         kwargs["body"] = body
 
         return self._update_aws_account_endpoint.call_with_http_info(**kwargs)

--- a/src/datadog_api_client/v1/api/aws_logs_integration_api.py
+++ b/src/datadog_api_client/v1/api/aws_logs_integration_api.py
@@ -1,7 +1,9 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, List
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.v1.model.aws_account_and_lambda_request import AWSAccountAndLambdaRequest
@@ -163,7 +165,10 @@ class AWSLogsIntegrationApi:
             api_client=api_client,
         )
 
-    def check_aws_logs_lambda_async(self, body, **kwargs):
+    def check_aws_logs_lambda_async(
+        self,
+        body: AWSAccountAndLambdaRequest,
+    ) -> AWSLogsAsyncResponse:
         """Check that an AWS Lambda Function exists.
 
         Test if permissions are present to add a log-forwarding triggers for the given services and AWS account. The input
@@ -180,11 +185,15 @@ class AWSLogsIntegrationApi:
         :type body: AWSAccountAndLambdaRequest
         :rtype: AWSLogsAsyncResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._check_aws_logs_lambda_async_endpoint.call_with_http_info(**kwargs)
 
-    def check_aws_logs_services_async(self, body, **kwargs):
+    def check_aws_logs_services_async(
+        self,
+        body: AWSLogsServicesRequest,
+    ) -> AWSLogsAsyncResponse:
         """Check permissions for log services.
 
         Test if permissions are present to add log-forwarding triggers for the
@@ -203,11 +212,15 @@ class AWSLogsIntegrationApi:
         :type body: AWSLogsServicesRequest
         :rtype: AWSLogsAsyncResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._check_aws_logs_services_async_endpoint.call_with_http_info(**kwargs)
 
-    def create_aws_lambda_arn(self, body, **kwargs):
+    def create_aws_lambda_arn(
+        self,
+        body: AWSAccountAndLambdaRequest,
+    ) -> dict:
         """Add AWS Log Lambda ARN.
 
         Attach the Lambda ARN of the Lambda created for the Datadog-AWS log collection to your AWS account ID to enable log collection.
@@ -216,11 +229,15 @@ class AWSLogsIntegrationApi:
         :type body: AWSAccountAndLambdaRequest
         :rtype: dict
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_aws_lambda_arn_endpoint.call_with_http_info(**kwargs)
 
-    def delete_aws_lambda_arn(self, body, **kwargs):
+    def delete_aws_lambda_arn(
+        self,
+        body: AWSAccountAndLambdaRequest,
+    ) -> dict:
         """Delete an AWS Logs integration.
 
         Delete a Datadog-AWS logs configuration by removing the specific Lambda ARN associated with a given AWS account.
@@ -229,11 +246,15 @@ class AWSLogsIntegrationApi:
         :type body: AWSAccountAndLambdaRequest
         :rtype: dict
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._delete_aws_lambda_arn_endpoint.call_with_http_info(**kwargs)
 
-    def enable_aws_log_services(self, body, **kwargs):
+    def enable_aws_log_services(
+        self,
+        body: AWSLogsServicesRequest,
+    ) -> dict:
         """Enable an AWS Logs integration.
 
         Enable automatic log collection for a list of services. This should be run after running ``CreateAWSLambdaARN`` to save the configuration.
@@ -242,24 +263,31 @@ class AWSLogsIntegrationApi:
         :type body: AWSLogsServicesRequest
         :rtype: dict
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._enable_aws_log_services_endpoint.call_with_http_info(**kwargs)
 
-    def list_aws_logs_integrations(self, **kwargs):
+    def list_aws_logs_integrations(
+        self,
+    ) -> List[AWSLogsListResponse]:
         """List all AWS Logs integrations.
 
         List all Datadog-AWS Logs integrations configured in your Datadog account.
 
         :rtype: [AWSLogsListResponse]
         """
+        kwargs: Dict[str, Any] = {}
         return self._list_aws_logs_integrations_endpoint.call_with_http_info(**kwargs)
 
-    def list_aws_logs_services(self, **kwargs):
+    def list_aws_logs_services(
+        self,
+    ) -> List[AWSLogsListServicesResponse]:
         """Get list of AWS log ready services.
 
         Get the list of current AWS services that Datadog offers automatic log collection. Use returned service IDs with the services parameter for the Enable an AWS service log collection API endpoint.
 
         :rtype: [AWSLogsListServicesResponse]
         """
+        kwargs: Dict[str, Any] = {}
         return self._list_aws_logs_services_endpoint.call_with_http_info(**kwargs)

--- a/src/datadog_api_client/v1/api/azure_integration_api.py
+++ b/src/datadog_api_client/v1/api/azure_integration_api.py
@@ -1,7 +1,9 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.v1.model.azure_account import AzureAccount
@@ -121,7 +123,10 @@ class AzureIntegrationApi:
             api_client=api_client,
         )
 
-    def create_azure_integration(self, body, **kwargs):
+    def create_azure_integration(
+        self,
+        body: AzureAccount,
+    ) -> dict:
         """Create an Azure integration.
 
         Create a Datadog-Azure integration.
@@ -136,11 +141,15 @@ class AzureIntegrationApi:
         :type body: AzureAccount
         :rtype: dict
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_azure_integration_endpoint.call_with_http_info(**kwargs)
 
-    def delete_azure_integration(self, body, **kwargs):
+    def delete_azure_integration(
+        self,
+        body: AzureAccount,
+    ) -> dict:
         """Delete an Azure integration.
 
         Delete a given Datadog-Azure integration from your Datadog account.
@@ -149,20 +158,27 @@ class AzureIntegrationApi:
         :type body: AzureAccount
         :rtype: dict
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._delete_azure_integration_endpoint.call_with_http_info(**kwargs)
 
-    def list_azure_integration(self, **kwargs):
+    def list_azure_integration(
+        self,
+    ) -> AzureAccountListResponse:
         """List all Azure integrations.
 
         List all Datadog-Azure integrations configured in your Datadog account.
 
         :rtype: AzureAccountListResponse
         """
+        kwargs: Dict[str, Any] = {}
         return self._list_azure_integration_endpoint.call_with_http_info(**kwargs)
 
-    def update_azure_host_filters(self, body, **kwargs):
+    def update_azure_host_filters(
+        self,
+        body: AzureAccount,
+    ) -> dict:
         """Update Azure integration host filters.
 
         Update the defined list of host filters for a given Datadog-Azure integration.
@@ -171,11 +187,15 @@ class AzureIntegrationApi:
         :type body: AzureAccount
         :rtype: dict
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._update_azure_host_filters_endpoint.call_with_http_info(**kwargs)
 
-    def update_azure_integration(self, body, **kwargs):
+    def update_azure_integration(
+        self,
+        body: AzureAccount,
+    ) -> dict:
         """Update an Azure integration.
 
         Update a Datadog-Azure integration. Requires an existing ``tenant_name`` and ``client_id``.
@@ -186,6 +206,7 @@ class AzureIntegrationApi:
         :type body: AzureAccount
         :rtype: dict
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._update_azure_integration_endpoint.call_with_http_info(**kwargs)

--- a/src/datadog_api_client/v1/api/dashboard_lists_api.py
+++ b/src/datadog_api_client/v1/api/dashboard_lists_api.py
@@ -1,7 +1,9 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.v1.model.dashboard_list_list_response import DashboardListListResponse
@@ -137,7 +139,10 @@ class DashboardListsApi:
             api_client=api_client,
         )
 
-    def create_dashboard_list(self, body, **kwargs):
+    def create_dashboard_list(
+        self,
+        body: DashboardList,
+    ) -> DashboardList:
         """Create a dashboard list.
 
         Create an empty dashboard list.
@@ -146,11 +151,15 @@ class DashboardListsApi:
         :type body: DashboardList
         :rtype: DashboardList
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_dashboard_list_endpoint.call_with_http_info(**kwargs)
 
-    def delete_dashboard_list(self, list_id, **kwargs):
+    def delete_dashboard_list(
+        self,
+        list_id: int,
+    ) -> DashboardListDeleteResponse:
         """Delete a dashboard list.
 
         Delete a dashboard list.
@@ -159,11 +168,15 @@ class DashboardListsApi:
         :type list_id: int
         :rtype: DashboardListDeleteResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["list_id"] = list_id
 
         return self._delete_dashboard_list_endpoint.call_with_http_info(**kwargs)
 
-    def get_dashboard_list(self, list_id, **kwargs):
+    def get_dashboard_list(
+        self,
+        list_id: int,
+    ) -> DashboardList:
         """Get a dashboard list.
 
         Fetch an existing dashboard list's definition.
@@ -172,20 +185,28 @@ class DashboardListsApi:
         :type list_id: int
         :rtype: DashboardList
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["list_id"] = list_id
 
         return self._get_dashboard_list_endpoint.call_with_http_info(**kwargs)
 
-    def list_dashboard_lists(self, **kwargs):
+    def list_dashboard_lists(
+        self,
+    ) -> DashboardListListResponse:
         """Get all dashboard lists.
 
         Fetch all of your existing dashboard list definitions.
 
         :rtype: DashboardListListResponse
         """
+        kwargs: Dict[str, Any] = {}
         return self._list_dashboard_lists_endpoint.call_with_http_info(**kwargs)
 
-    def update_dashboard_list(self, list_id, body, **kwargs):
+    def update_dashboard_list(
+        self,
+        list_id: int,
+        body: DashboardList,
+    ) -> DashboardList:
         """Update a dashboard list.
 
         Update the name of a dashboard list.
@@ -196,6 +217,7 @@ class DashboardListsApi:
         :type body: DashboardList
         :rtype: DashboardList
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["list_id"] = list_id
 
         kwargs["body"] = body

--- a/src/datadog_api_client/v1/api/dashboards_api.py
+++ b/src/datadog_api_client/v1/api/dashboards_api.py
@@ -1,9 +1,15 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
+from datadog_api_client.model_utils import (
+    UnsetType,
+    unset,
+)
 from datadog_api_client.v1.model.dashboard_bulk_delete_request import DashboardBulkDeleteRequest
 from datadog_api_client.v1.model.dashboard_summary import DashboardSummary
 from datadog_api_client.v1.model.dashboard_restore_request import DashboardRestoreRequest
@@ -191,7 +197,10 @@ class DashboardsApi:
             api_client=api_client,
         )
 
-    def create_dashboard(self, body, **kwargs):
+    def create_dashboard(
+        self,
+        body: Dashboard,
+    ) -> Dashboard:
         """Create a new dashboard.
 
         Create a dashboard using the specified options. When defining queries in your widgets, take note of which queries should have the ``as_count()`` or ``as_rate()`` modifiers appended.
@@ -201,11 +210,15 @@ class DashboardsApi:
         :type body: Dashboard
         :rtype: Dashboard
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_dashboard_endpoint.call_with_http_info(**kwargs)
 
-    def delete_dashboard(self, dashboard_id, **kwargs):
+    def delete_dashboard(
+        self,
+        dashboard_id: str,
+    ) -> DashboardDeleteResponse:
         """Delete a dashboard.
 
         Delete a dashboard using the specified ID.
@@ -214,11 +227,15 @@ class DashboardsApi:
         :type dashboard_id: str
         :rtype: DashboardDeleteResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["dashboard_id"] = dashboard_id
 
         return self._delete_dashboard_endpoint.call_with_http_info(**kwargs)
 
-    def delete_dashboards(self, body, **kwargs):
+    def delete_dashboards(
+        self,
+        body: DashboardBulkDeleteRequest,
+    ) -> None:
         """Delete dashboards.
 
         Delete dashboards using the specified IDs. If there are any failures, no dashboards will be deleted (partial success is not allowed).
@@ -227,11 +244,15 @@ class DashboardsApi:
         :type body: DashboardBulkDeleteRequest
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._delete_dashboards_endpoint.call_with_http_info(**kwargs)
 
-    def get_dashboard(self, dashboard_id, **kwargs):
+    def get_dashboard(
+        self,
+        dashboard_id: str,
+    ) -> Dashboard:
         """Get a dashboard.
 
         Get a dashboard using the specified ID.
@@ -240,11 +261,17 @@ class DashboardsApi:
         :type dashboard_id: str
         :rtype: Dashboard
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["dashboard_id"] = dashboard_id
 
         return self._get_dashboard_endpoint.call_with_http_info(**kwargs)
 
-    def list_dashboards(self, **kwargs):
+    def list_dashboards(
+        self,
+        *,
+        filter_shared: Union[bool, UnsetType] = unset,
+        filter_deleted: Union[bool, UnsetType] = unset,
+    ) -> DashboardSummary:
         """Get all dashboards.
 
         Get all dashboards.
@@ -260,9 +287,19 @@ class DashboardsApi:
         :type filter_deleted: bool, optional
         :rtype: DashboardSummary
         """
+        kwargs: Dict[str, Any] = {}
+        if filter_shared is not unset:
+            kwargs["filter_shared"] = filter_shared
+
+        if filter_deleted is not unset:
+            kwargs["filter_deleted"] = filter_deleted
+
         return self._list_dashboards_endpoint.call_with_http_info(**kwargs)
 
-    def restore_dashboards(self, body, **kwargs):
+    def restore_dashboards(
+        self,
+        body: DashboardRestoreRequest,
+    ) -> None:
         """Restore deleted dashboards.
 
         Restore dashboards using the specified IDs. If there are any failures, no dashboards will be restored (partial success is not allowed).
@@ -271,11 +308,16 @@ class DashboardsApi:
         :type body: DashboardRestoreRequest
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._restore_dashboards_endpoint.call_with_http_info(**kwargs)
 
-    def update_dashboard(self, dashboard_id, body, **kwargs):
+    def update_dashboard(
+        self,
+        dashboard_id: str,
+        body: Dashboard,
+    ) -> Dashboard:
         """Update a dashboard.
 
         Update a dashboard using the specified ID.
@@ -286,6 +328,7 @@ class DashboardsApi:
         :type body: Dashboard
         :rtype: Dashboard
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["dashboard_id"] = dashboard_id
 
         kwargs["body"] = body

--- a/src/datadog_api_client/v1/api/downtimes_api.py
+++ b/src/datadog_api_client/v1/api/downtimes_api.py
@@ -1,9 +1,15 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, List, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
+from datadog_api_client.model_utils import (
+    UnsetType,
+    unset,
+)
 from datadog_api_client.v1.model.downtime import Downtime
 from datadog_api_client.v1.model.canceled_downtimes_ids import CanceledDowntimesIds
 from datadog_api_client.v1.model.cancel_downtimes_by_scope_request import CancelDowntimesByScopeRequest
@@ -190,7 +196,10 @@ class DowntimesApi:
             api_client=api_client,
         )
 
-    def cancel_downtime(self, downtime_id, **kwargs):
+    def cancel_downtime(
+        self,
+        downtime_id: int,
+    ) -> None:
         """Cancel a downtime.
 
         Cancel a downtime.
@@ -199,11 +208,15 @@ class DowntimesApi:
         :type downtime_id: int
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["downtime_id"] = downtime_id
 
         return self._cancel_downtime_endpoint.call_with_http_info(**kwargs)
 
-    def cancel_downtimes_by_scope(self, body, **kwargs):
+    def cancel_downtimes_by_scope(
+        self,
+        body: CancelDowntimesByScopeRequest,
+    ) -> CanceledDowntimesIds:
         """Cancel downtimes by scope.
 
         Delete all downtimes that match the scope of ``X``.
@@ -212,11 +225,15 @@ class DowntimesApi:
         :type body: CancelDowntimesByScopeRequest
         :rtype: CanceledDowntimesIds
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._cancel_downtimes_by_scope_endpoint.call_with_http_info(**kwargs)
 
-    def create_downtime(self, body, **kwargs):
+    def create_downtime(
+        self,
+        body: Downtime,
+    ) -> Downtime:
         """Schedule a downtime.
 
         Schedule a downtime.
@@ -225,11 +242,15 @@ class DowntimesApi:
         :type body: Downtime
         :rtype: Downtime
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_downtime_endpoint.call_with_http_info(**kwargs)
 
-    def get_downtime(self, downtime_id, **kwargs):
+    def get_downtime(
+        self,
+        downtime_id: int,
+    ) -> Downtime:
         """Get a downtime.
 
         Get downtime detail by ``downtime_id``.
@@ -238,11 +259,16 @@ class DowntimesApi:
         :type downtime_id: int
         :rtype: Downtime
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["downtime_id"] = downtime_id
 
         return self._get_downtime_endpoint.call_with_http_info(**kwargs)
 
-    def list_downtimes(self, **kwargs):
+    def list_downtimes(
+        self,
+        *,
+        current_only: Union[bool, UnsetType] = unset,
+    ) -> List[Downtime]:
         """Get all downtimes.
 
         Get all scheduled downtimes.
@@ -251,9 +277,16 @@ class DowntimesApi:
         :type current_only: bool, optional
         :rtype: [Downtime]
         """
+        kwargs: Dict[str, Any] = {}
+        if current_only is not unset:
+            kwargs["current_only"] = current_only
+
         return self._list_downtimes_endpoint.call_with_http_info(**kwargs)
 
-    def list_monitor_downtimes(self, monitor_id, **kwargs):
+    def list_monitor_downtimes(
+        self,
+        monitor_id: int,
+    ) -> List[Downtime]:
         """Get all downtimes for a monitor.
 
         Get all active downtimes for the specified monitor.
@@ -262,11 +295,16 @@ class DowntimesApi:
         :type monitor_id: int
         :rtype: [Downtime]
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["monitor_id"] = monitor_id
 
         return self._list_monitor_downtimes_endpoint.call_with_http_info(**kwargs)
 
-    def update_downtime(self, downtime_id, body, **kwargs):
+    def update_downtime(
+        self,
+        downtime_id: int,
+        body: Downtime,
+    ) -> Downtime:
         """Update a downtime.
 
         Update a single downtime by ``downtime_id``.
@@ -277,6 +315,7 @@ class DowntimesApi:
         :type body: Downtime
         :rtype: Downtime
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["downtime_id"] = downtime_id
 
         kwargs["body"] = body

--- a/src/datadog_api_client/v1/api/events_api.py
+++ b/src/datadog_api_client/v1/api/events_api.py
@@ -1,9 +1,15 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
+from datadog_api_client.model_utils import (
+    UnsetType,
+    unset,
+)
 from datadog_api_client.v1.model.event_list_response import EventListResponse
 from datadog_api_client.v1.model.event_priority import EventPriority
 from datadog_api_client.v1.model.event_create_response import EventCreateResponse
@@ -133,7 +139,10 @@ class EventsApi:
             api_client=api_client,
         )
 
-    def create_event(self, body, **kwargs):
+    def create_event(
+        self,
+        body: EventCreateRequest,
+    ) -> EventCreateResponse:
         """Post an event.
 
         This endpoint allows you to post events to the stream.
@@ -143,11 +152,15 @@ class EventsApi:
         :type body: EventCreateRequest
         :rtype: EventCreateResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_event_endpoint.call_with_http_info(**kwargs)
 
-    def get_event(self, event_id, **kwargs):
+    def get_event(
+        self,
+        event_id: int,
+    ) -> EventResponse:
         """Get an event.
 
         This endpoint allows you to query for event details.
@@ -159,11 +172,23 @@ class EventsApi:
         :type event_id: int
         :rtype: EventResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["event_id"] = event_id
 
         return self._get_event_endpoint.call_with_http_info(**kwargs)
 
-    def list_events(self, start, end, **kwargs):
+    def list_events(
+        self,
+        start: int,
+        end: int,
+        *,
+        priority: Union[EventPriority, UnsetType] = unset,
+        sources: Union[str, UnsetType] = unset,
+        tags: Union[str, UnsetType] = unset,
+        unaggregated: Union[bool, UnsetType] = unset,
+        exclude_aggregate: Union[bool, UnsetType] = unset,
+        page: Union[int, UnsetType] = unset,
+    ) -> EventListResponse:
         """Query the event stream.
 
         The event stream can be queried and filtered by time, priority, sources and tags.
@@ -202,8 +227,27 @@ class EventsApi:
         :type page: int, optional
         :rtype: EventListResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start"] = start
 
         kwargs["end"] = end
+
+        if priority is not unset:
+            kwargs["priority"] = priority
+
+        if sources is not unset:
+            kwargs["sources"] = sources
+
+        if tags is not unset:
+            kwargs["tags"] = tags
+
+        if unaggregated is not unset:
+            kwargs["unaggregated"] = unaggregated
+
+        if exclude_aggregate is not unset:
+            kwargs["exclude_aggregate"] = exclude_aggregate
+
+        if page is not unset:
+            kwargs["page"] = page
 
         return self._list_events_endpoint.call_with_http_info(**kwargs)

--- a/src/datadog_api_client/v1/api/gcp_integration_api.py
+++ b/src/datadog_api_client/v1/api/gcp_integration_api.py
@@ -1,7 +1,9 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.v1.model.gcp_account import GCPAccount
@@ -100,7 +102,10 @@ class GCPIntegrationApi:
             api_client=api_client,
         )
 
-    def create_gcp_integration(self, body, **kwargs):
+    def create_gcp_integration(
+        self,
+        body: GCPAccount,
+    ) -> dict:
         """Create a GCP integration.
 
         Create a Datadog-GCP integration.
@@ -109,11 +114,15 @@ class GCPIntegrationApi:
         :type body: GCPAccount
         :rtype: dict
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_gcp_integration_endpoint.call_with_http_info(**kwargs)
 
-    def delete_gcp_integration(self, body, **kwargs):
+    def delete_gcp_integration(
+        self,
+        body: GCPAccount,
+    ) -> dict:
         """Delete a GCP integration.
 
         Delete a given Datadog-GCP integration.
@@ -122,20 +131,27 @@ class GCPIntegrationApi:
         :type body: GCPAccount
         :rtype: dict
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._delete_gcp_integration_endpoint.call_with_http_info(**kwargs)
 
-    def list_gcp_integration(self, **kwargs):
+    def list_gcp_integration(
+        self,
+    ) -> GCPAccountListResponse:
         """List all GCP integrations.
 
         List all Datadog-GCP integrations configured in your Datadog account.
 
         :rtype: GCPAccountListResponse
         """
+        kwargs: Dict[str, Any] = {}
         return self._list_gcp_integration_endpoint.call_with_http_info(**kwargs)
 
-    def update_gcp_integration(self, body, **kwargs):
+    def update_gcp_integration(
+        self,
+        body: GCPAccount,
+    ) -> dict:
         """Update a GCP integration.
 
         Update a Datadog-GCP integrations host_filters and/or auto-mute.
@@ -147,6 +163,7 @@ class GCPIntegrationApi:
         :type body: GCPAccount
         :rtype: dict
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._update_gcp_integration_endpoint.call_with_http_info(**kwargs)

--- a/src/datadog_api_client/v1/api/hosts_api.py
+++ b/src/datadog_api_client/v1/api/hosts_api.py
@@ -1,9 +1,15 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
+from datadog_api_client.model_utils import (
+    UnsetType,
+    unset,
+)
 from datadog_api_client.v1.model.host_mute_response import HostMuteResponse
 from datadog_api_client.v1.model.host_mute_settings import HostMuteSettings
 from datadog_api_client.v1.model.host_list_response import HostListResponse
@@ -155,7 +161,11 @@ class HostsApi:
             api_client=api_client,
         )
 
-    def get_host_totals(self, **kwargs):
+    def get_host_totals(
+        self,
+        *,
+        _from: Union[int, UnsetType] = unset,
+    ) -> HostTotals:
         """Get the total number of active hosts.
 
         This endpoint returns the total number of active and up hosts in your Datadog account.
@@ -165,9 +175,24 @@ class HostsApi:
         :type _from: int, optional
         :rtype: HostTotals
         """
+        kwargs: Dict[str, Any] = {}
+        if _from is not unset:
+            kwargs["_from"] = _from
+
         return self._get_host_totals_endpoint.call_with_http_info(**kwargs)
 
-    def list_hosts(self, **kwargs):
+    def list_hosts(
+        self,
+        *,
+        filter: Union[str, UnsetType] = unset,
+        sort_field: Union[str, UnsetType] = unset,
+        sort_dir: Union[str, UnsetType] = unset,
+        start: Union[int, UnsetType] = unset,
+        count: Union[int, UnsetType] = unset,
+        _from: Union[int, UnsetType] = unset,
+        include_muted_hosts_data: Union[bool, UnsetType] = unset,
+        include_hosts_metadata: Union[bool, UnsetType] = unset,
+    ) -> HostListResponse:
         """Get all hosts for your organization.
 
         This endpoint allows searching for hosts by name, alias, or tag.
@@ -193,9 +218,38 @@ class HostsApi:
         :type include_hosts_metadata: bool, optional
         :rtype: HostListResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if filter is not unset:
+            kwargs["filter"] = filter
+
+        if sort_field is not unset:
+            kwargs["sort_field"] = sort_field
+
+        if sort_dir is not unset:
+            kwargs["sort_dir"] = sort_dir
+
+        if start is not unset:
+            kwargs["start"] = start
+
+        if count is not unset:
+            kwargs["count"] = count
+
+        if _from is not unset:
+            kwargs["_from"] = _from
+
+        if include_muted_hosts_data is not unset:
+            kwargs["include_muted_hosts_data"] = include_muted_hosts_data
+
+        if include_hosts_metadata is not unset:
+            kwargs["include_hosts_metadata"] = include_hosts_metadata
+
         return self._list_hosts_endpoint.call_with_http_info(**kwargs)
 
-    def mute_host(self, host_name, body, **kwargs):
+    def mute_host(
+        self,
+        host_name: str,
+        body: HostMuteSettings,
+    ) -> HostMuteResponse:
         """Mute a host.
 
         Mute a host.
@@ -206,13 +260,17 @@ class HostsApi:
         :type body: HostMuteSettings
         :rtype: HostMuteResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["host_name"] = host_name
 
         kwargs["body"] = body
 
         return self._mute_host_endpoint.call_with_http_info(**kwargs)
 
-    def unmute_host(self, host_name, **kwargs):
+    def unmute_host(
+        self,
+        host_name: str,
+    ) -> HostMuteResponse:
         """Unmute a host.
 
         Unmutes a host. This endpoint takes no JSON arguments.
@@ -221,6 +279,7 @@ class HostsApi:
         :type host_name: str
         :rtype: HostMuteResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["host_name"] = host_name
 
         return self._unmute_host_endpoint.call_with_http_info(**kwargs)

--- a/src/datadog_api_client/v1/api/ip_ranges_api.py
+++ b/src/datadog_api_client/v1/api/ip_ranges_api.py
@@ -1,7 +1,9 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.v1.model.ip_ranges import IPRanges
@@ -78,11 +80,14 @@ class IPRangesApi:
             api_client=api_client,
         )
 
-    def get_ip_ranges(self, **kwargs):
+    def get_ip_ranges(
+        self,
+    ) -> IPRanges:
         """List IP Ranges.
 
         Get information about Datadog IP ranges.
 
         :rtype: IPRanges
         """
+        kwargs: Dict[str, Any] = {}
         return self._get_ip_ranges_endpoint.call_with_http_info(**kwargs)

--- a/src/datadog_api_client/v1/api/key_management_api.py
+++ b/src/datadog_api_client/v1/api/key_management_api.py
@@ -1,7 +1,9 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.v1.model.api_key_list_response import ApiKeyListResponse
@@ -257,7 +259,10 @@ class KeyManagementApi:
             api_client=api_client,
         )
 
-    def create_api_key(self, body, **kwargs):
+    def create_api_key(
+        self,
+        body: ApiKey,
+    ) -> ApiKeyResponse:
         """Create an API key.
 
         Creates an API key with a given name.
@@ -265,11 +270,15 @@ class KeyManagementApi:
         :type body: ApiKey
         :rtype: ApiKeyResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_api_key_endpoint.call_with_http_info(**kwargs)
 
-    def create_application_key(self, body, **kwargs):
+    def create_application_key(
+        self,
+        body: ApplicationKey,
+    ) -> ApplicationKeyResponse:
         """Create an application key.
 
         Create an application key with a given name.
@@ -277,11 +286,15 @@ class KeyManagementApi:
         :type body: ApplicationKey
         :rtype: ApplicationKeyResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_application_key_endpoint.call_with_http_info(**kwargs)
 
-    def delete_api_key(self, key, **kwargs):
+    def delete_api_key(
+        self,
+        key: str,
+    ) -> ApiKeyResponse:
         """Delete an API key.
 
         Delete a given API key.
@@ -290,11 +303,15 @@ class KeyManagementApi:
         :type key: str
         :rtype: ApiKeyResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["key"] = key
 
         return self._delete_api_key_endpoint.call_with_http_info(**kwargs)
 
-    def delete_application_key(self, key, **kwargs):
+    def delete_application_key(
+        self,
+        key: str,
+    ) -> ApplicationKeyResponse:
         """Delete an application key.
 
         Delete a given application key.
@@ -303,11 +320,15 @@ class KeyManagementApi:
         :type key: str
         :rtype: ApplicationKeyResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["key"] = key
 
         return self._delete_application_key_endpoint.call_with_http_info(**kwargs)
 
-    def get_api_key(self, key, **kwargs):
+    def get_api_key(
+        self,
+        key: str,
+    ) -> ApiKeyResponse:
         """Get API key.
 
         Get a given API key.
@@ -316,11 +337,15 @@ class KeyManagementApi:
         :type key: str
         :rtype: ApiKeyResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["key"] = key
 
         return self._get_api_key_endpoint.call_with_http_info(**kwargs)
 
-    def get_application_key(self, key, **kwargs):
+    def get_application_key(
+        self,
+        key: str,
+    ) -> ApplicationKeyResponse:
         """Get an application key.
 
         Get a given application key.
@@ -329,29 +354,40 @@ class KeyManagementApi:
         :type key: str
         :rtype: ApplicationKeyResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["key"] = key
 
         return self._get_application_key_endpoint.call_with_http_info(**kwargs)
 
-    def list_api_keys(self, **kwargs):
+    def list_api_keys(
+        self,
+    ) -> ApiKeyListResponse:
         """Get all API keys.
 
         Get all API keys available for your account.
 
         :rtype: ApiKeyListResponse
         """
+        kwargs: Dict[str, Any] = {}
         return self._list_api_keys_endpoint.call_with_http_info(**kwargs)
 
-    def list_application_keys(self, **kwargs):
+    def list_application_keys(
+        self,
+    ) -> ApplicationKeyListResponse:
         """Get all application keys.
 
         Get all application keys available for your Datadog account.
 
         :rtype: ApplicationKeyListResponse
         """
+        kwargs: Dict[str, Any] = {}
         return self._list_application_keys_endpoint.call_with_http_info(**kwargs)
 
-    def update_api_key(self, key, body, **kwargs):
+    def update_api_key(
+        self,
+        key: str,
+        body: ApiKey,
+    ) -> ApiKeyResponse:
         """Edit an API key.
 
         Edit an API key name.
@@ -361,13 +397,18 @@ class KeyManagementApi:
         :type body: ApiKey
         :rtype: ApiKeyResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["key"] = key
 
         kwargs["body"] = body
 
         return self._update_api_key_endpoint.call_with_http_info(**kwargs)
 
-    def update_application_key(self, key, body, **kwargs):
+    def update_application_key(
+        self,
+        key: str,
+        body: ApplicationKey,
+    ) -> ApplicationKeyResponse:
         """Edit an application key.
 
         Edit an application key name.
@@ -377,6 +418,7 @@ class KeyManagementApi:
         :type body: ApplicationKey
         :rtype: ApplicationKeyResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["key"] = key
 
         kwargs["body"] = body

--- a/src/datadog_api_client/v1/api/logs_api.py
+++ b/src/datadog_api_client/v1/api/logs_api.py
@@ -1,9 +1,15 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
+from datadog_api_client.model_utils import (
+    UnsetType,
+    unset,
+)
 from datadog_api_client.v1.model.logs_list_response import LogsListResponse
 from datadog_api_client.v1.model.logs_list_request import LogsListRequest
 from datadog_api_client.v1.model.content_encoding import ContentEncoding
@@ -123,7 +129,10 @@ class LogsApi:
             api_client=api_client,
         )
 
-    def list_logs(self, body, **kwargs):
+    def list_logs(
+        self,
+        body: LogsListRequest,
+    ) -> LogsListResponse:
         """Search logs.
 
         List endpoint returns logs that match a log search query.
@@ -137,11 +146,18 @@ class LogsApi:
         :type body: LogsListRequest
         :rtype: LogsListResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._list_logs_endpoint.call_with_http_info(**kwargs)
 
-    def submit_log(self, body, **kwargs):
+    def submit_log(
+        self,
+        body: HTTPLog,
+        *,
+        content_encoding: Union[ContentEncoding, UnsetType] = unset,
+        ddtags: Union[str, UnsetType] = unset,
+    ) -> dict:
         """Send logs.
 
         Send your logs to your Datadog platform over HTTP. Limits per HTTP request are:
@@ -177,6 +193,13 @@ class LogsApi:
         :type ddtags: str, optional
         :rtype: dict
         """
+        kwargs: Dict[str, Any] = {}
+        if content_encoding is not unset:
+            kwargs["content_encoding"] = content_encoding
+
+        if ddtags is not unset:
+            kwargs["ddtags"] = ddtags
+
         kwargs["body"] = body
 
         return self._submit_log_endpoint.call_with_http_info(**kwargs)

--- a/src/datadog_api_client/v1/api/logs_indexes_api.py
+++ b/src/datadog_api_client/v1/api/logs_indexes_api.py
@@ -1,7 +1,9 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.v1.model.logs_indexes_order import LogsIndexesOrder
@@ -151,7 +153,10 @@ class LogsIndexesApi:
             api_client=api_client,
         )
 
-    def create_logs_index(self, body, **kwargs):
+    def create_logs_index(
+        self,
+        body: LogsIndex,
+    ) -> LogsIndex:
         """Create an index.
 
         Creates a new index. Returns the Index object passed in the request body when the request is successful.
@@ -160,11 +165,15 @@ class LogsIndexesApi:
         :type body: LogsIndex
         :rtype: LogsIndex
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_logs_index_endpoint.call_with_http_info(**kwargs)
 
-    def get_logs_index(self, name, **kwargs):
+    def get_logs_index(
+        self,
+        name: str,
+    ) -> LogsIndex:
         """Get an index.
 
         Get one log index from your organization. This endpoint takes no JSON arguments.
@@ -173,20 +182,26 @@ class LogsIndexesApi:
         :type name: str
         :rtype: LogsIndex
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["name"] = name
 
         return self._get_logs_index_endpoint.call_with_http_info(**kwargs)
 
-    def get_logs_index_order(self, **kwargs):
+    def get_logs_index_order(
+        self,
+    ) -> LogsIndexesOrder:
         """Get indexes order.
 
         Get the current order of your log indexes. This endpoint takes no JSON arguments.
 
         :rtype: LogsIndexesOrder
         """
+        kwargs: Dict[str, Any] = {}
         return self._get_logs_index_order_endpoint.call_with_http_info(**kwargs)
 
-    def list_log_indexes(self, **kwargs):
+    def list_log_indexes(
+        self,
+    ) -> LogsIndexListResponse:
         """Get all indexes.
 
         The Index object describes the configuration of a log index.
@@ -194,9 +209,14 @@ class LogsIndexesApi:
 
         :rtype: LogsIndexListResponse
         """
+        kwargs: Dict[str, Any] = {}
         return self._list_log_indexes_endpoint.call_with_http_info(**kwargs)
 
-    def update_logs_index(self, name, body, **kwargs):
+    def update_logs_index(
+        self,
+        name: str,
+        body: LogsIndexUpdateRequest,
+    ) -> LogsIndex:
         """Update an index.
 
         Update an index as identified by its name.
@@ -211,13 +231,17 @@ class LogsIndexesApi:
         :type body: LogsIndexUpdateRequest
         :rtype: LogsIndex
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["name"] = name
 
         kwargs["body"] = body
 
         return self._update_logs_index_endpoint.call_with_http_info(**kwargs)
 
-    def update_logs_index_order(self, body, **kwargs):
+    def update_logs_index_order(
+        self,
+        body: LogsIndexesOrder,
+    ) -> LogsIndexesOrder:
         """Update indexes order.
 
         This endpoint updates the index order of your organization.
@@ -227,6 +251,7 @@ class LogsIndexesApi:
         :type body: LogsIndexesOrder
         :rtype: LogsIndexesOrder
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._update_logs_index_order_endpoint.call_with_http_info(**kwargs)

--- a/src/datadog_api_client/v1/api/logs_pipelines_api.py
+++ b/src/datadog_api_client/v1/api/logs_pipelines_api.py
@@ -1,7 +1,9 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.v1.model.logs_pipelines_order import LogsPipelinesOrder
@@ -201,7 +203,10 @@ class LogsPipelinesApi:
             api_client=api_client,
         )
 
-    def create_logs_pipeline(self, body, **kwargs):
+    def create_logs_pipeline(
+        self,
+        body: LogsPipeline,
+    ) -> LogsPipeline:
         """Create a pipeline.
 
         Create a pipeline in your organization.
@@ -210,11 +215,15 @@ class LogsPipelinesApi:
         :type body: LogsPipeline
         :rtype: LogsPipeline
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_logs_pipeline_endpoint.call_with_http_info(**kwargs)
 
-    def delete_logs_pipeline(self, pipeline_id, **kwargs):
+    def delete_logs_pipeline(
+        self,
+        pipeline_id: str,
+    ) -> None:
         """Delete a pipeline.
 
         Delete a given pipeline from your organization.
@@ -224,11 +233,15 @@ class LogsPipelinesApi:
         :type pipeline_id: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["pipeline_id"] = pipeline_id
 
         return self._delete_logs_pipeline_endpoint.call_with_http_info(**kwargs)
 
-    def get_logs_pipeline(self, pipeline_id, **kwargs):
+    def get_logs_pipeline(
+        self,
+        pipeline_id: str,
+    ) -> LogsPipeline:
         """Get a pipeline.
 
         Get a specific pipeline from your organization.
@@ -238,11 +251,14 @@ class LogsPipelinesApi:
         :type pipeline_id: str
         :rtype: LogsPipeline
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["pipeline_id"] = pipeline_id
 
         return self._get_logs_pipeline_endpoint.call_with_http_info(**kwargs)
 
-    def get_logs_pipeline_order(self, **kwargs):
+    def get_logs_pipeline_order(
+        self,
+    ) -> LogsPipelinesOrder:
         """Get pipeline order.
 
         Get the current order of your pipelines.
@@ -250,9 +266,12 @@ class LogsPipelinesApi:
 
         :rtype: LogsPipelinesOrder
         """
+        kwargs: Dict[str, Any] = {}
         return self._get_logs_pipeline_order_endpoint.call_with_http_info(**kwargs)
 
-    def list_logs_pipelines(self, **kwargs):
+    def list_logs_pipelines(
+        self,
+    ) -> LogsPipelineList:
         """Get all pipelines.
 
         Get all pipelines from your organization.
@@ -260,9 +279,14 @@ class LogsPipelinesApi:
 
         :rtype: LogsPipelineList
         """
+        kwargs: Dict[str, Any] = {}
         return self._list_logs_pipelines_endpoint.call_with_http_info(**kwargs)
 
-    def update_logs_pipeline(self, pipeline_id, body, **kwargs):
+    def update_logs_pipeline(
+        self,
+        pipeline_id: str,
+        body: LogsPipeline,
+    ) -> LogsPipeline:
         """Update a pipeline.
 
         Update a given pipeline configuration to change it’s processors or their order.
@@ -276,13 +300,17 @@ class LogsPipelinesApi:
         :type body: LogsPipeline
         :rtype: LogsPipeline
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["pipeline_id"] = pipeline_id
 
         kwargs["body"] = body
 
         return self._update_logs_pipeline_endpoint.call_with_http_info(**kwargs)
 
-    def update_logs_pipeline_order(self, body, **kwargs):
+    def update_logs_pipeline_order(
+        self,
+        body: LogsPipelinesOrder,
+    ) -> LogsPipelinesOrder:
         """Update pipeline order.
 
         Update the order of your pipelines. Since logs are processed sequentially, reordering a pipeline may change
@@ -295,6 +323,7 @@ class LogsPipelinesApi:
         :type body: LogsPipelinesOrder
         :rtype: LogsPipelinesOrder
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._update_logs_pipeline_order_endpoint.call_with_http_info(**kwargs)

--- a/src/datadog_api_client/v1/api/metrics_api.py
+++ b/src/datadog_api_client/v1/api/metrics_api.py
@@ -6,17 +6,13 @@ from __future__ import annotations
 from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
-<<<<<<< HEAD
-from datadog_api_client.v1.model.intake_payload_accepted import IntakePayloadAccepted
-from datadog_api_client.v1.model.distribution_points_content_encoding import DistributionPointsContentEncoding
-from datadog_api_client.v1.model.distribution_points_payload import DistributionPointsPayload
-||||||| parent of 507957976 (Add typing information)
-=======
 from datadog_api_client.model_utils import (
     UnsetType,
     unset,
 )
->>>>>>> 507957976 (Add typing information)
+from datadog_api_client.v1.model.intake_payload_accepted import IntakePayloadAccepted
+from datadog_api_client.v1.model.distribution_points_content_encoding import DistributionPointsContentEncoding
+from datadog_api_client.v1.model.distribution_points_payload import DistributionPointsPayload
 from datadog_api_client.v1.model.metrics_list_response import MetricsListResponse
 from datadog_api_client.v1.model.metric_metadata import MetricMetadata
 from datadog_api_client.v1.model.metrics_query_response import MetricsQueryResponse
@@ -342,8 +338,12 @@ class MetricsApi:
 
         return self._query_metrics_endpoint.call_with_http_info(**kwargs)
 
-<<<<<<< HEAD
-    def submit_distribution_points(self, body, **kwargs):
+    def submit_distribution_points(
+        self,
+        body: DistributionPointsPayload,
+        *,
+        content_encoding: Union[DistributionPointsContentEncoding, UnsetType] = unset,
+    ) -> IntakePayloadAccepted:
         """Submit distribution points.
 
         The distribution points end-point allows you to post distribution data that can be graphed on Datadog’s dashboards.
@@ -353,21 +353,20 @@ class MetricsApi:
         :type content_encoding: DistributionPointsContentEncoding, optional
         :rtype: IntakePayloadAccepted
         """
+        kwargs: Dict[str, Any] = {}
+        if content_encoding is not unset:
+            kwargs["content_encoding"] = content_encoding
+
         kwargs["body"] = body
 
         return self._submit_distribution_points_endpoint.call_with_http_info(**kwargs)
 
-    def submit_metrics(self, body, **kwargs):
-||||||| parent of 507957976 (Add typing information)
-    def submit_metrics(self, body, **kwargs):
-=======
     def submit_metrics(
         self,
         body: MetricsPayload,
         *,
         content_encoding: Union[MetricContentEncoding, UnsetType] = unset,
     ) -> IntakePayloadAccepted:
->>>>>>> 507957976 (Add typing information)
         """Submit metrics.
 
         The metrics end-point allows you to post time-series data that can be graphed on Datadog’s dashboards.

--- a/src/datadog_api_client/v1/api/metrics_api.py
+++ b/src/datadog_api_client/v1/api/metrics_api.py
@@ -1,12 +1,22 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
+<<<<<<< HEAD
 from datadog_api_client.v1.model.intake_payload_accepted import IntakePayloadAccepted
 from datadog_api_client.v1.model.distribution_points_content_encoding import DistributionPointsContentEncoding
 from datadog_api_client.v1.model.distribution_points_payload import DistributionPointsPayload
+||||||| parent of 507957976 (Add typing information)
+=======
+from datadog_api_client.model_utils import (
+    UnsetType,
+    unset,
+)
+>>>>>>> 507957976 (Add typing information)
 from datadog_api_client.v1.model.metrics_list_response import MetricsListResponse
 from datadog_api_client.v1.model.metric_metadata import MetricMetadata
 from datadog_api_client.v1.model.metrics_query_response import MetricsQueryResponse
@@ -239,7 +249,10 @@ class MetricsApi:
             api_client=api_client,
         )
 
-    def get_metric_metadata(self, metric_name, **kwargs):
+    def get_metric_metadata(
+        self,
+        metric_name: str,
+    ) -> MetricMetadata:
         """Get metric metadata.
 
         Get metadata about a specific metric.
@@ -248,11 +261,18 @@ class MetricsApi:
         :type metric_name: str
         :rtype: MetricMetadata
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["metric_name"] = metric_name
 
         return self._get_metric_metadata_endpoint.call_with_http_info(**kwargs)
 
-    def list_active_metrics(self, _from, **kwargs):
+    def list_active_metrics(
+        self,
+        _from: int,
+        *,
+        host: Union[str, UnsetType] = unset,
+        tag_filter: Union[str, UnsetType] = unset,
+    ) -> MetricsListResponse:
         """Get active metrics list.
 
         Get the list of actively reporting metrics from a given time until now.
@@ -267,11 +287,21 @@ class MetricsApi:
         :type tag_filter: str, optional
         :rtype: MetricsListResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["_from"] = _from
+
+        if host is not unset:
+            kwargs["host"] = host
+
+        if tag_filter is not unset:
+            kwargs["tag_filter"] = tag_filter
 
         return self._list_active_metrics_endpoint.call_with_http_info(**kwargs)
 
-    def list_metrics(self, q, **kwargs):
+    def list_metrics(
+        self,
+        q: str,
+    ) -> MetricSearchResponse:
         """Search metrics.
 
         Search for metrics from the last 24 hours in Datadog.
@@ -280,11 +310,17 @@ class MetricsApi:
         :type q: str
         :rtype: MetricSearchResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["q"] = q
 
         return self._list_metrics_endpoint.call_with_http_info(**kwargs)
 
-    def query_metrics(self, _from, to, query, **kwargs):
+    def query_metrics(
+        self,
+        _from: int,
+        to: int,
+        query: str,
+    ) -> MetricsQueryResponse:
         """Query timeseries points.
 
         Query timeseries points.
@@ -297,6 +333,7 @@ class MetricsApi:
         :type query: str
         :rtype: MetricsQueryResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["_from"] = _from
 
         kwargs["to"] = to
@@ -305,6 +342,7 @@ class MetricsApi:
 
         return self._query_metrics_endpoint.call_with_http_info(**kwargs)
 
+<<<<<<< HEAD
     def submit_distribution_points(self, body, **kwargs):
         """Submit distribution points.
 
@@ -320,6 +358,16 @@ class MetricsApi:
         return self._submit_distribution_points_endpoint.call_with_http_info(**kwargs)
 
     def submit_metrics(self, body, **kwargs):
+||||||| parent of 507957976 (Add typing information)
+    def submit_metrics(self, body, **kwargs):
+=======
+    def submit_metrics(
+        self,
+        body: MetricsPayload,
+        *,
+        content_encoding: Union[MetricContentEncoding, UnsetType] = unset,
+    ) -> IntakePayloadAccepted:
+>>>>>>> 507957976 (Add typing information)
         """Submit metrics.
 
         The metrics end-point allows you to post time-series data that can be graphed on Datadog’s dashboards.
@@ -340,11 +388,19 @@ class MetricsApi:
         :type content_encoding: MetricContentEncoding, optional
         :rtype: IntakePayloadAccepted
         """
+        kwargs: Dict[str, Any] = {}
+        if content_encoding is not unset:
+            kwargs["content_encoding"] = content_encoding
+
         kwargs["body"] = body
 
         return self._submit_metrics_endpoint.call_with_http_info(**kwargs)
 
-    def update_metric_metadata(self, metric_name, body, **kwargs):
+    def update_metric_metadata(
+        self,
+        metric_name: str,
+        body: MetricMetadata,
+    ) -> MetricMetadata:
         """Edit metric metadata.
 
         Edit metadata of a specific metric. Find out more about `supported types <https://docs.datadoghq.com/developers/metrics>`_.
@@ -355,6 +411,7 @@ class MetricsApi:
         :type body: MetricMetadata
         :rtype: MetricMetadata
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["metric_name"] = metric_name
 
         kwargs["body"] = body

--- a/src/datadog_api_client/v1/api/monitors_api.py
+++ b/src/datadog_api_client/v1/api/monitors_api.py
@@ -1,9 +1,15 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, List, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
+from datadog_api_client.model_utils import (
+    UnsetType,
+    unset,
+)
 from datadog_api_client.v1.model.monitor import Monitor
 from datadog_api_client.v1.model.check_can_delete_monitor_response import CheckCanDeleteMonitorResponse
 from datadog_api_client.v1.model.monitor_group_search_response import MonitorGroupSearchResponse
@@ -347,7 +353,10 @@ class MonitorsApi:
             api_client=api_client,
         )
 
-    def check_can_delete_monitor(self, monitor_ids, **kwargs):
+    def check_can_delete_monitor(
+        self,
+        monitor_ids: List[int],
+    ) -> CheckCanDeleteMonitorResponse:
         """Check if a monitor can be deleted.
 
         Check if the given monitors can be deleted.
@@ -356,11 +365,15 @@ class MonitorsApi:
         :type monitor_ids: [int]
         :rtype: CheckCanDeleteMonitorResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["monitor_ids"] = monitor_ids
 
         return self._check_can_delete_monitor_endpoint.call_with_http_info(**kwargs)
 
-    def create_monitor(self, body, **kwargs):
+    def create_monitor(
+        self,
+        body: Monitor,
+    ) -> Monitor:
         """Create a monitor.
 
         Create a monitor using the specified options.
@@ -565,11 +578,17 @@ class MonitorsApi:
         :type body: Monitor
         :rtype: Monitor
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_monitor_endpoint.call_with_http_info(**kwargs)
 
-    def delete_monitor(self, monitor_id, **kwargs):
+    def delete_monitor(
+        self,
+        monitor_id: int,
+        *,
+        force: Union[str, UnsetType] = unset,
+    ) -> DeletedMonitor:
         """Delete a monitor.
 
         Delete the specified monitor
@@ -580,11 +599,20 @@ class MonitorsApi:
         :type force: str, optional
         :rtype: DeletedMonitor
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["monitor_id"] = monitor_id
+
+        if force is not unset:
+            kwargs["force"] = force
 
         return self._delete_monitor_endpoint.call_with_http_info(**kwargs)
 
-    def get_monitor(self, monitor_id, **kwargs):
+    def get_monitor(
+        self,
+        monitor_id: int,
+        *,
+        group_states: Union[str, UnsetType] = unset,
+    ) -> Monitor:
         """Get a monitor's details.
 
         Get details about the specified monitor from your organization.
@@ -595,11 +623,26 @@ class MonitorsApi:
         :type group_states: str, optional
         :rtype: Monitor
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["monitor_id"] = monitor_id
+
+        if group_states is not unset:
+            kwargs["group_states"] = group_states
 
         return self._get_monitor_endpoint.call_with_http_info(**kwargs)
 
-    def list_monitors(self, **kwargs):
+    def list_monitors(
+        self,
+        *,
+        group_states: Union[str, UnsetType] = unset,
+        name: Union[str, UnsetType] = unset,
+        tags: Union[str, UnsetType] = unset,
+        monitor_tags: Union[str, UnsetType] = unset,
+        with_downtimes: Union[bool, UnsetType] = unset,
+        id_offset: Union[int, UnsetType] = unset,
+        page: Union[int, UnsetType] = unset,
+        page_size: Union[int, UnsetType] = unset,
+    ) -> List[Monitor]:
         """Get all monitor details.
 
         Get details about the specified monitor from your organization.
@@ -625,9 +668,41 @@ class MonitorsApi:
         :type page_size: int, optional
         :rtype: [Monitor]
         """
+        kwargs: Dict[str, Any] = {}
+        if group_states is not unset:
+            kwargs["group_states"] = group_states
+
+        if name is not unset:
+            kwargs["name"] = name
+
+        if tags is not unset:
+            kwargs["tags"] = tags
+
+        if monitor_tags is not unset:
+            kwargs["monitor_tags"] = monitor_tags
+
+        if with_downtimes is not unset:
+            kwargs["with_downtimes"] = with_downtimes
+
+        if id_offset is not unset:
+            kwargs["id_offset"] = id_offset
+
+        if page is not unset:
+            kwargs["page"] = page
+
+        if page_size is not unset:
+            kwargs["page_size"] = page_size
+
         return self._list_monitors_endpoint.call_with_http_info(**kwargs)
 
-    def search_monitor_groups(self, **kwargs):
+    def search_monitor_groups(
+        self,
+        *,
+        query: Union[str, UnsetType] = unset,
+        page: Union[int, UnsetType] = unset,
+        per_page: Union[int, UnsetType] = unset,
+        sort: Union[str, UnsetType] = unset,
+    ) -> MonitorGroupSearchResponse:
         """Monitors group search.
 
         Search and filter your monitor groups details.
@@ -651,9 +726,29 @@ class MonitorsApi:
         :type sort: str, optional
         :rtype: MonitorGroupSearchResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if query is not unset:
+            kwargs["query"] = query
+
+        if page is not unset:
+            kwargs["page"] = page
+
+        if per_page is not unset:
+            kwargs["per_page"] = per_page
+
+        if sort is not unset:
+            kwargs["sort"] = sort
+
         return self._search_monitor_groups_endpoint.call_with_http_info(**kwargs)
 
-    def search_monitors(self, **kwargs):
+    def search_monitors(
+        self,
+        *,
+        query: Union[str, UnsetType] = unset,
+        page: Union[int, UnsetType] = unset,
+        per_page: Union[int, UnsetType] = unset,
+        sort: Union[str, UnsetType] = unset,
+    ) -> MonitorSearchResponse:
         """Monitors search.
 
         Search and filter your monitors details.
@@ -677,9 +772,26 @@ class MonitorsApi:
         :type sort: str, optional
         :rtype: MonitorSearchResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if query is not unset:
+            kwargs["query"] = query
+
+        if page is not unset:
+            kwargs["page"] = page
+
+        if per_page is not unset:
+            kwargs["per_page"] = per_page
+
+        if sort is not unset:
+            kwargs["sort"] = sort
+
         return self._search_monitors_endpoint.call_with_http_info(**kwargs)
 
-    def update_monitor(self, monitor_id, body, **kwargs):
+    def update_monitor(
+        self,
+        monitor_id: int,
+        body: MonitorUpdateRequest,
+    ) -> Monitor:
         """Edit a monitor.
 
         Edit the specified monitor.
@@ -690,13 +802,18 @@ class MonitorsApi:
         :type body: MonitorUpdateRequest
         :rtype: Monitor
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["monitor_id"] = monitor_id
 
         kwargs["body"] = body
 
         return self._update_monitor_endpoint.call_with_http_info(**kwargs)
 
-    def validate_existing_monitor(self, monitor_id, body, **kwargs):
+    def validate_existing_monitor(
+        self,
+        monitor_id: int,
+        body: Monitor,
+    ) -> dict:
         """Validate an existing monitor.
 
         Validate the monitor provided in the request.
@@ -707,13 +824,17 @@ class MonitorsApi:
         :type body: Monitor
         :rtype: dict
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["monitor_id"] = monitor_id
 
         kwargs["body"] = body
 
         return self._validate_existing_monitor_endpoint.call_with_http_info(**kwargs)
 
-    def validate_monitor(self, body, **kwargs):
+    def validate_monitor(
+        self,
+        body: Monitor,
+    ) -> dict:
         """Validate a monitor.
 
         Validate the monitor provided in the request.
@@ -722,6 +843,7 @@ class MonitorsApi:
         :type body: Monitor
         :rtype: dict
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._validate_monitor_endpoint.call_with_http_info(**kwargs)

--- a/src/datadog_api_client/v1/api/notebooks_api.py
+++ b/src/datadog_api_client/v1/api/notebooks_api.py
@@ -1,9 +1,15 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
+from datadog_api_client.model_utils import (
+    UnsetType,
+    unset,
+)
 from datadog_api_client.v1.model.notebooks_response import NotebooksResponse
 from datadog_api_client.v1.model.notebook_response import NotebookResponse
 from datadog_api_client.v1.model.notebook_create_request import NotebookCreateRequest
@@ -189,7 +195,10 @@ class NotebooksApi:
             api_client=api_client,
         )
 
-    def create_notebook(self, body, **kwargs):
+    def create_notebook(
+        self,
+        body: NotebookCreateRequest,
+    ) -> NotebookResponse:
         """Create a notebook.
 
         Create a notebook using the specified options.
@@ -198,11 +207,15 @@ class NotebooksApi:
         :type body: NotebookCreateRequest
         :rtype: NotebookResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_notebook_endpoint.call_with_http_info(**kwargs)
 
-    def delete_notebook(self, notebook_id, **kwargs):
+    def delete_notebook(
+        self,
+        notebook_id: int,
+    ) -> None:
         """Delete a notebook.
 
         Delete a notebook using the specified ID.
@@ -211,11 +224,15 @@ class NotebooksApi:
         :type notebook_id: int
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["notebook_id"] = notebook_id
 
         return self._delete_notebook_endpoint.call_with_http_info(**kwargs)
 
-    def get_notebook(self, notebook_id, **kwargs):
+    def get_notebook(
+        self,
+        notebook_id: int,
+    ) -> NotebookResponse:
         """Get a notebook.
 
         Get a notebook using the specified notebook ID.
@@ -224,11 +241,25 @@ class NotebooksApi:
         :type notebook_id: int
         :rtype: NotebookResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["notebook_id"] = notebook_id
 
         return self._get_notebook_endpoint.call_with_http_info(**kwargs)
 
-    def list_notebooks(self, **kwargs):
+    def list_notebooks(
+        self,
+        *,
+        author_handle: Union[str, UnsetType] = unset,
+        exclude_author_handle: Union[str, UnsetType] = unset,
+        start: Union[int, UnsetType] = unset,
+        count: Union[int, UnsetType] = unset,
+        sort_field: Union[str, UnsetType] = unset,
+        sort_dir: Union[str, UnsetType] = unset,
+        query: Union[str, UnsetType] = unset,
+        include_cells: Union[bool, UnsetType] = unset,
+        is_template: Union[bool, UnsetType] = unset,
+        type: Union[str, UnsetType] = unset,
+    ) -> NotebooksResponse:
         """Get all notebooks.
 
         Get all notebooks. This can also be used to search for notebooks with a particular ``query`` in the notebook
@@ -256,9 +287,44 @@ class NotebooksApi:
         :type type: str, optional
         :rtype: NotebooksResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if author_handle is not unset:
+            kwargs["author_handle"] = author_handle
+
+        if exclude_author_handle is not unset:
+            kwargs["exclude_author_handle"] = exclude_author_handle
+
+        if start is not unset:
+            kwargs["start"] = start
+
+        if count is not unset:
+            kwargs["count"] = count
+
+        if sort_field is not unset:
+            kwargs["sort_field"] = sort_field
+
+        if sort_dir is not unset:
+            kwargs["sort_dir"] = sort_dir
+
+        if query is not unset:
+            kwargs["query"] = query
+
+        if include_cells is not unset:
+            kwargs["include_cells"] = include_cells
+
+        if is_template is not unset:
+            kwargs["is_template"] = is_template
+
+        if type is not unset:
+            kwargs["type"] = type
+
         return self._list_notebooks_endpoint.call_with_http_info(**kwargs)
 
-    def update_notebook(self, notebook_id, body, **kwargs):
+    def update_notebook(
+        self,
+        notebook_id: int,
+        body: NotebookUpdateRequest,
+    ) -> NotebookResponse:
         """Update a notebook.
 
         Update a notebook using the specified ID.
@@ -269,6 +335,7 @@ class NotebooksApi:
         :type body: NotebookUpdateRequest
         :rtype: NotebookResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["notebook_id"] = notebook_id
 
         kwargs["body"] = body

--- a/src/datadog_api_client/v1/api/organizations_api.py
+++ b/src/datadog_api_client/v1/api/organizations_api.py
@@ -198,8 +198,10 @@ class OrganizationsApi:
 
         return self._create_child_org_endpoint.call_with_http_info(**kwargs)
 
-<<<<<<< HEAD
-    def downgrade_org(self, public_id, **kwargs):
+    def downgrade_org(
+        self,
+        public_id: str,
+    ) -> OrgDowngradedResponse:
         """Spin-off Child Organization.
 
         Only available for MSP customers. Removes a child organization from the hierarchy of the master organization and places the child organization on a 30-day trial.
@@ -208,19 +210,15 @@ class OrganizationsApi:
         :type public_id: str
         :rtype: OrgDowngradedResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["public_id"] = public_id
 
         return self._downgrade_org_endpoint.call_with_http_info(**kwargs)
 
-    def get_org(self, public_id, **kwargs):
-||||||| parent of 507957976 (Add typing information)
-    def get_org(self, public_id, **kwargs):
-=======
     def get_org(
         self,
         public_id: str,
     ) -> OrganizationResponse:
->>>>>>> 507957976 (Add typing information)
         """Get organization information.
 
         Get organization information.

--- a/src/datadog_api_client/v1/api/organizations_api.py
+++ b/src/datadog_api_client/v1/api/organizations_api.py
@@ -1,7 +1,9 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.model_utils import (
@@ -170,7 +172,10 @@ class OrganizationsApi:
             api_client=api_client,
         )
 
-    def create_child_org(self, body, **kwargs):
+    def create_child_org(
+        self,
+        body: OrganizationCreateBody,
+    ) -> OrganizationCreateResponse:
         """Create a child organization.
 
         Create a child organization.
@@ -188,10 +193,12 @@ class OrganizationsApi:
         :type body: OrganizationCreateBody
         :rtype: OrganizationCreateResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_child_org_endpoint.call_with_http_info(**kwargs)
 
+<<<<<<< HEAD
     def downgrade_org(self, public_id, **kwargs):
         """Spin-off Child Organization.
 
@@ -206,6 +213,14 @@ class OrganizationsApi:
         return self._downgrade_org_endpoint.call_with_http_info(**kwargs)
 
     def get_org(self, public_id, **kwargs):
+||||||| parent of 507957976 (Add typing information)
+    def get_org(self, public_id, **kwargs):
+=======
+    def get_org(
+        self,
+        public_id: str,
+    ) -> OrganizationResponse:
+>>>>>>> 507957976 (Add typing information)
         """Get organization information.
 
         Get organization information.
@@ -214,20 +229,28 @@ class OrganizationsApi:
         :type public_id: str
         :rtype: OrganizationResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["public_id"] = public_id
 
         return self._get_org_endpoint.call_with_http_info(**kwargs)
 
-    def list_orgs(self, **kwargs):
+    def list_orgs(
+        self,
+    ) -> OrganizationListResponse:
         """List your managed organizations.
 
         This endpoint returns data on your top-level organization.
 
         :rtype: OrganizationListResponse
         """
+        kwargs: Dict[str, Any] = {}
         return self._list_orgs_endpoint.call_with_http_info(**kwargs)
 
-    def update_org(self, public_id, body, **kwargs):
+    def update_org(
+        self,
+        public_id: str,
+        body: Organization,
+    ) -> OrganizationResponse:
         """Update your organization.
 
         Update your organization.
@@ -237,13 +260,18 @@ class OrganizationsApi:
         :type body: Organization
         :rtype: OrganizationResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["public_id"] = public_id
 
         kwargs["body"] = body
 
         return self._update_org_endpoint.call_with_http_info(**kwargs)
 
-    def upload_idp_for_org(self, public_id, idp_file, **kwargs):
+    def upload_idp_for_org(
+        self,
+        public_id: str,
+        idp_file: file_type,
+    ) -> IdpResponse:
         """Upload IdP metadata.
 
         There are a couple of options for updating the Identity Provider (IdP)
@@ -262,6 +290,7 @@ class OrganizationsApi:
         :type idp_file: file_type
         :rtype: IdpResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["public_id"] = public_id
 
         kwargs["idp_file"] = idp_file

--- a/src/datadog_api_client/v1/api/pager_duty_integration_api.py
+++ b/src/datadog_api_client/v1/api/pager_duty_integration_api.py
@@ -1,7 +1,9 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.v1.model.pager_duty_service_name import PagerDutyServiceName
@@ -118,7 +120,10 @@ class PagerDutyIntegrationApi:
             api_client=api_client,
         )
 
-    def create_pager_duty_integration_service(self, body, **kwargs):
+    def create_pager_duty_integration_service(
+        self,
+        body: PagerDutyService,
+    ) -> PagerDutyServiceName:
         """Create a new service object.
 
         Create a new service object in the PagerDuty integration.
@@ -127,11 +132,15 @@ class PagerDutyIntegrationApi:
         :type body: PagerDutyService
         :rtype: PagerDutyServiceName
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_pager_duty_integration_service_endpoint.call_with_http_info(**kwargs)
 
-    def delete_pager_duty_integration_service(self, service_name, **kwargs):
+    def delete_pager_duty_integration_service(
+        self,
+        service_name: str,
+    ) -> None:
         """Delete a single service object.
 
         Delete a single service object in the Datadog-PagerDuty integration.
@@ -140,11 +149,15 @@ class PagerDutyIntegrationApi:
         :type service_name: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["service_name"] = service_name
 
         return self._delete_pager_duty_integration_service_endpoint.call_with_http_info(**kwargs)
 
-    def get_pager_duty_integration_service(self, service_name, **kwargs):
+    def get_pager_duty_integration_service(
+        self,
+        service_name: str,
+    ) -> PagerDutyServiceName:
         """Get a single service object.
 
         Get service name in the Datadog-PagerDuty integration.
@@ -153,11 +166,16 @@ class PagerDutyIntegrationApi:
         :type service_name: str
         :rtype: PagerDutyServiceName
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["service_name"] = service_name
 
         return self._get_pager_duty_integration_service_endpoint.call_with_http_info(**kwargs)
 
-    def update_pager_duty_integration_service(self, service_name, body, **kwargs):
+    def update_pager_duty_integration_service(
+        self,
+        service_name: str,
+        body: PagerDutyServiceKey,
+    ) -> None:
         """Update a single service object.
 
         Update a single service object in the Datadog-PagerDuty integration.
@@ -168,6 +186,7 @@ class PagerDutyIntegrationApi:
         :type body: PagerDutyServiceKey
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["service_name"] = service_name
 
         kwargs["body"] = body

--- a/src/datadog_api_client/v1/api/security_monitoring_api.py
+++ b/src/datadog_api_client/v1/api/security_monitoring_api.py
@@ -1,7 +1,9 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.v1.model.successful_signal_update_response import SuccessfulSignalUpdateResponse
@@ -102,7 +104,11 @@ class SecurityMonitoringApi:
             api_client=api_client,
         )
 
-    def add_security_monitoring_signal_to_incident(self, signal_id, body, **kwargs):
+    def add_security_monitoring_signal_to_incident(
+        self,
+        signal_id: str,
+        body: AddSignalToIncidentRequest,
+    ) -> SuccessfulSignalUpdateResponse:
         """Add a security signal to an incident.
 
         Add a security signal to an incident. This makes it possible to search for signals by incident within the signal explorer and to view the signals on the incident timeline.
@@ -113,13 +119,18 @@ class SecurityMonitoringApi:
         :type body: AddSignalToIncidentRequest
         :rtype: SuccessfulSignalUpdateResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["signal_id"] = signal_id
 
         kwargs["body"] = body
 
         return self._add_security_monitoring_signal_to_incident_endpoint.call_with_http_info(**kwargs)
 
-    def edit_security_monitoring_signal_assignee(self, signal_id, body, **kwargs):
+    def edit_security_monitoring_signal_assignee(
+        self,
+        signal_id: str,
+        body: SignalAssigneeUpdateRequest,
+    ) -> SuccessfulSignalUpdateResponse:
         """Modify the triage assignee of a security signal.
 
         Modify the triage assignee of a security signal.
@@ -130,13 +141,18 @@ class SecurityMonitoringApi:
         :type body: SignalAssigneeUpdateRequest
         :rtype: SuccessfulSignalUpdateResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["signal_id"] = signal_id
 
         kwargs["body"] = body
 
         return self._edit_security_monitoring_signal_assignee_endpoint.call_with_http_info(**kwargs)
 
-    def edit_security_monitoring_signal_state(self, signal_id, body, **kwargs):
+    def edit_security_monitoring_signal_state(
+        self,
+        signal_id: str,
+        body: SignalStateUpdateRequest,
+    ) -> SuccessfulSignalUpdateResponse:
         """Change the triage state of a security signal.
 
         Change the triage state of a security signal.
@@ -147,6 +163,7 @@ class SecurityMonitoringApi:
         :type body: SignalStateUpdateRequest
         :rtype: SuccessfulSignalUpdateResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["signal_id"] = signal_id
 
         kwargs["body"] = body

--- a/src/datadog_api_client/v1/api/service_checks_api.py
+++ b/src/datadog_api_client/v1/api/service_checks_api.py
@@ -1,7 +1,9 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.v1.model.intake_payload_accepted import IntakePayloadAccepted
@@ -51,7 +53,10 @@ class ServiceChecksApi:
             api_client=api_client,
         )
 
-    def submit_service_check(self, body, **kwargs):
+    def submit_service_check(
+        self,
+        body: ServiceChecks,
+    ) -> IntakePayloadAccepted:
         """Submit a Service Check.
 
         Submit a list of Service Checks.
@@ -66,6 +71,7 @@ class ServiceChecksApi:
         :type body: ServiceChecks
         :rtype: IntakePayloadAccepted
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._submit_service_check_endpoint.call_with_http_info(**kwargs)

--- a/src/datadog_api_client/v1/api/service_level_objective_corrections_api.py
+++ b/src/datadog_api_client/v1/api/service_level_objective_corrections_api.py
@@ -1,7 +1,9 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.v1.model.slo_correction_list_response import SLOCorrectionListResponse
@@ -139,7 +141,10 @@ class ServiceLevelObjectiveCorrectionsApi:
             api_client=api_client,
         )
 
-    def create_slo_correction(self, body, **kwargs):
+    def create_slo_correction(
+        self,
+        body: SLOCorrectionCreateRequest,
+    ) -> SLOCorrectionResponse:
         """Create an SLO correction.
 
         Create an SLO Correction.
@@ -148,11 +153,15 @@ class ServiceLevelObjectiveCorrectionsApi:
         :type body: SLOCorrectionCreateRequest
         :rtype: SLOCorrectionResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_slo_correction_endpoint.call_with_http_info(**kwargs)
 
-    def delete_slo_correction(self, slo_correction_id, **kwargs):
+    def delete_slo_correction(
+        self,
+        slo_correction_id: str,
+    ) -> None:
         """Delete an SLO correction.
 
         Permanently delete the specified SLO correction object.
@@ -161,11 +170,15 @@ class ServiceLevelObjectiveCorrectionsApi:
         :type slo_correction_id: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["slo_correction_id"] = slo_correction_id
 
         return self._delete_slo_correction_endpoint.call_with_http_info(**kwargs)
 
-    def get_slo_correction(self, slo_correction_id, **kwargs):
+    def get_slo_correction(
+        self,
+        slo_correction_id: str,
+    ) -> SLOCorrectionResponse:
         """Get an SLO correction for an SLO.
 
         Get an SLO correction.
@@ -174,20 +187,28 @@ class ServiceLevelObjectiveCorrectionsApi:
         :type slo_correction_id: str
         :rtype: SLOCorrectionResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["slo_correction_id"] = slo_correction_id
 
         return self._get_slo_correction_endpoint.call_with_http_info(**kwargs)
 
-    def list_slo_correction(self, **kwargs):
+    def list_slo_correction(
+        self,
+    ) -> SLOCorrectionListResponse:
         """Get all SLO corrections.
 
         Get all Service Level Objective corrections.
 
         :rtype: SLOCorrectionListResponse
         """
+        kwargs: Dict[str, Any] = {}
         return self._list_slo_correction_endpoint.call_with_http_info(**kwargs)
 
-    def update_slo_correction(self, slo_correction_id, body, **kwargs):
+    def update_slo_correction(
+        self,
+        slo_correction_id: str,
+        body: SLOCorrectionUpdateRequest,
+    ) -> SLOCorrectionResponse:
         """Update an SLO correction.
 
         Update the specified SLO correction object.
@@ -198,6 +219,7 @@ class ServiceLevelObjectiveCorrectionsApi:
         :type body: SLOCorrectionUpdateRequest
         :rtype: SLOCorrectionResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["slo_correction_id"] = slo_correction_id
 
         kwargs["body"] = body

--- a/src/datadog_api_client/v1/api/service_level_objectives_api.py
+++ b/src/datadog_api_client/v1/api/service_level_objectives_api.py
@@ -618,8 +618,13 @@ class ServiceLevelObjectivesApi:
 
         return self._list_slos_endpoint.call_with_http_info(**kwargs)
 
-<<<<<<< HEAD
-    def search_slo(self, **kwargs):
+    def search_slo(
+        self,
+        *,
+        query: Union[str, UnsetType] = unset,
+        page_size: Union[int, UnsetType] = unset,
+        page_number: Union[int, UnsetType] = unset,
+    ) -> SearchSLOResponse:
         """Search for SLOs.
 
         Get a list of service level objective objects for your organization.
@@ -632,18 +637,23 @@ class ServiceLevelObjectivesApi:
         :type page_number: int, optional
         :rtype: SearchSLOResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if query is not unset:
+            kwargs["query"] = query
+
+        if page_size is not unset:
+            kwargs["page_size"] = page_size
+
+        if page_number is not unset:
+            kwargs["page_number"] = page_number
+
         return self._search_slo_endpoint.call_with_http_info(**kwargs)
 
-    def update_slo(self, slo_id, body, **kwargs):
-||||||| parent of 507957976 (Add typing information)
-    def update_slo(self, slo_id, body, **kwargs):
-=======
     def update_slo(
         self,
         slo_id: str,
         body: ServiceLevelObjective,
     ) -> SLOListResponse:
->>>>>>> 507957976 (Add typing information)
         """Update an SLO.
 
         Update the specified service level objective object.

--- a/src/datadog_api_client/v1/api/service_level_objectives_api.py
+++ b/src/datadog_api_client/v1/api/service_level_objectives_api.py
@@ -1,9 +1,15 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
+from datadog_api_client.model_utils import (
+    UnsetType,
+    unset,
+)
 from datadog_api_client.v1.model.slo_list_response import SLOListResponse
 from datadog_api_client.v1.model.service_level_objective_request import ServiceLevelObjectiveRequest
 from datadog_api_client.v1.model.slo_bulk_delete_response import SLOBulkDeleteResponse
@@ -391,7 +397,10 @@ class ServiceLevelObjectivesApi:
             api_client=api_client,
         )
 
-    def check_can_delete_slo(self, ids, **kwargs):
+    def check_can_delete_slo(
+        self,
+        ids: str,
+    ) -> CheckCanDeleteSLOResponse:
         """Check if SLOs can be safely deleted.
 
         Check if an SLO can be safely deleted. For example,
@@ -401,11 +410,15 @@ class ServiceLevelObjectivesApi:
         :type ids: str
         :rtype: CheckCanDeleteSLOResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["ids"] = ids
 
         return self._check_can_delete_slo_endpoint.call_with_http_info(**kwargs)
 
-    def create_slo(self, body, **kwargs):
+    def create_slo(
+        self,
+        body: ServiceLevelObjectiveRequest,
+    ) -> SLOListResponse:
         """Create an SLO object.
 
         Create a service level objective object.
@@ -414,11 +427,17 @@ class ServiceLevelObjectivesApi:
         :type body: ServiceLevelObjectiveRequest
         :rtype: SLOListResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_slo_endpoint.call_with_http_info(**kwargs)
 
-    def delete_slo(self, slo_id, **kwargs):
+    def delete_slo(
+        self,
+        slo_id: str,
+        *,
+        force: Union[str, UnsetType] = unset,
+    ) -> SLODeleteResponse:
         """Delete an SLO.
 
         Permanently delete the specified service level objective object.
@@ -432,11 +451,18 @@ class ServiceLevelObjectivesApi:
         :type force: str, optional
         :rtype: SLODeleteResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["slo_id"] = slo_id
+
+        if force is not unset:
+            kwargs["force"] = force
 
         return self._delete_slo_endpoint.call_with_http_info(**kwargs)
 
-    def delete_slo_timeframe_in_bulk(self, body, **kwargs):
+    def delete_slo_timeframe_in_bulk(
+        self,
+        body: SLOBulkDelete,
+    ) -> SLOBulkDeleteResponse:
         """Bulk Delete SLO Timeframes.
 
         Delete (or partially delete) multiple service level objective objects.
@@ -449,11 +475,17 @@ class ServiceLevelObjectivesApi:
         :type body: SLOBulkDelete
         :rtype: SLOBulkDeleteResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._delete_slo_timeframe_in_bulk_endpoint.call_with_http_info(**kwargs)
 
-    def get_slo(self, slo_id, **kwargs):
+    def get_slo(
+        self,
+        slo_id: str,
+        *,
+        with_configured_alert_ids: Union[bool, UnsetType] = unset,
+    ) -> SLOResponse:
         """Get an SLO's details.
 
         Get a service level objective object.
@@ -464,11 +496,18 @@ class ServiceLevelObjectivesApi:
         :type with_configured_alert_ids: bool, optional
         :rtype: SLOResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["slo_id"] = slo_id
+
+        if with_configured_alert_ids is not unset:
+            kwargs["with_configured_alert_ids"] = with_configured_alert_ids
 
         return self._get_slo_endpoint.call_with_http_info(**kwargs)
 
-    def get_slo_corrections(self, slo_id, **kwargs):
+    def get_slo_corrections(
+        self,
+        slo_id: str,
+    ) -> SLOCorrectionListResponse:
         """Get Corrections For an SLO.
 
         Get corrections applied to an SLO
@@ -477,11 +516,20 @@ class ServiceLevelObjectivesApi:
         :type slo_id: str
         :rtype: SLOCorrectionListResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["slo_id"] = slo_id
 
         return self._get_slo_corrections_endpoint.call_with_http_info(**kwargs)
 
-    def get_slo_history(self, slo_id, from_ts, to_ts, **kwargs):
+    def get_slo_history(
+        self,
+        slo_id: str,
+        from_ts: int,
+        to_ts: int,
+        *,
+        target: Union[float, UnsetType] = unset,
+        apply_correction: Union[bool, UnsetType] = unset,
+    ) -> SLOHistoryResponse:
         """Get an SLO's history.
 
         Get a specific SLO’s history, regardless of its SLO type.
@@ -506,15 +554,31 @@ class ServiceLevelObjectivesApi:
         :type apply_correction: bool, optional
         :rtype: SLOHistoryResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["slo_id"] = slo_id
 
         kwargs["from_ts"] = from_ts
 
         kwargs["to_ts"] = to_ts
 
+        if target is not unset:
+            kwargs["target"] = target
+
+        if apply_correction is not unset:
+            kwargs["apply_correction"] = apply_correction
+
         return self._get_slo_history_endpoint.call_with_http_info(**kwargs)
 
-    def list_slos(self, **kwargs):
+    def list_slos(
+        self,
+        *,
+        ids: Union[str, UnsetType] = unset,
+        query: Union[str, UnsetType] = unset,
+        tags_query: Union[str, UnsetType] = unset,
+        metrics_query: Union[str, UnsetType] = unset,
+        limit: Union[int, UnsetType] = unset,
+        offset: Union[int, UnsetType] = unset,
+    ) -> SLOListResponse:
         """Get all SLOs.
 
         Get a list of service level objective objects for your organization.
@@ -533,8 +597,28 @@ class ServiceLevelObjectivesApi:
         :type offset: int, optional
         :rtype: SLOListResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if ids is not unset:
+            kwargs["ids"] = ids
+
+        if query is not unset:
+            kwargs["query"] = query
+
+        if tags_query is not unset:
+            kwargs["tags_query"] = tags_query
+
+        if metrics_query is not unset:
+            kwargs["metrics_query"] = metrics_query
+
+        if limit is not unset:
+            kwargs["limit"] = limit
+
+        if offset is not unset:
+            kwargs["offset"] = offset
+
         return self._list_slos_endpoint.call_with_http_info(**kwargs)
 
+<<<<<<< HEAD
     def search_slo(self, **kwargs):
         """Search for SLOs.
 
@@ -551,6 +635,15 @@ class ServiceLevelObjectivesApi:
         return self._search_slo_endpoint.call_with_http_info(**kwargs)
 
     def update_slo(self, slo_id, body, **kwargs):
+||||||| parent of 507957976 (Add typing information)
+    def update_slo(self, slo_id, body, **kwargs):
+=======
+    def update_slo(
+        self,
+        slo_id: str,
+        body: ServiceLevelObjective,
+    ) -> SLOListResponse:
+>>>>>>> 507957976 (Add typing information)
         """Update an SLO.
 
         Update the specified service level objective object.
@@ -561,6 +654,7 @@ class ServiceLevelObjectivesApi:
         :type body: ServiceLevelObjective
         :rtype: SLOListResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["slo_id"] = slo_id
 
         kwargs["body"] = body

--- a/src/datadog_api_client/v1/api/slack_integration_api.py
+++ b/src/datadog_api_client/v1/api/slack_integration_api.py
@@ -1,7 +1,9 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.v1.model.slack_integration_channels import SlackIntegrationChannels
@@ -166,7 +168,11 @@ class SlackIntegrationApi:
             api_client=api_client,
         )
 
-    def create_slack_integration_channel(self, account_name, body, **kwargs):
+    def create_slack_integration_channel(
+        self,
+        account_name: str,
+        body: SlackIntegrationChannel,
+    ) -> SlackIntegrationChannel:
         """Create a Slack integration channel.
 
         Add a channel to your Datadog-Slack integration.
@@ -177,13 +183,18 @@ class SlackIntegrationApi:
         :type body: SlackIntegrationChannel
         :rtype: SlackIntegrationChannel
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["account_name"] = account_name
 
         kwargs["body"] = body
 
         return self._create_slack_integration_channel_endpoint.call_with_http_info(**kwargs)
 
-    def get_slack_integration_channel(self, account_name, channel_name, **kwargs):
+    def get_slack_integration_channel(
+        self,
+        account_name: str,
+        channel_name: str,
+    ) -> SlackIntegrationChannel:
         """Get a Slack integration channel.
 
         Get a channel configured for your Datadog-Slack integration.
@@ -194,13 +205,17 @@ class SlackIntegrationApi:
         :type channel_name: str
         :rtype: SlackIntegrationChannel
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["account_name"] = account_name
 
         kwargs["channel_name"] = channel_name
 
         return self._get_slack_integration_channel_endpoint.call_with_http_info(**kwargs)
 
-    def get_slack_integration_channels(self, account_name, **kwargs):
+    def get_slack_integration_channels(
+        self,
+        account_name: str,
+    ) -> SlackIntegrationChannels:
         """Get all channels in a Slack integration.
 
         Get a list of all channels configured for your Datadog-Slack integration.
@@ -209,11 +224,16 @@ class SlackIntegrationApi:
         :type account_name: str
         :rtype: SlackIntegrationChannels
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["account_name"] = account_name
 
         return self._get_slack_integration_channels_endpoint.call_with_http_info(**kwargs)
 
-    def remove_slack_integration_channel(self, account_name, channel_name, **kwargs):
+    def remove_slack_integration_channel(
+        self,
+        account_name: str,
+        channel_name: str,
+    ) -> None:
         """Remove a Slack integration channel.
 
         Remove a channel from your Datadog-Slack integration.
@@ -224,13 +244,19 @@ class SlackIntegrationApi:
         :type channel_name: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["account_name"] = account_name
 
         kwargs["channel_name"] = channel_name
 
         return self._remove_slack_integration_channel_endpoint.call_with_http_info(**kwargs)
 
-    def update_slack_integration_channel(self, account_name, channel_name, body, **kwargs):
+    def update_slack_integration_channel(
+        self,
+        account_name: str,
+        channel_name: str,
+        body: SlackIntegrationChannel,
+    ) -> SlackIntegrationChannel:
         """Update a Slack integration channel.
 
         Update a channel used in your Datadog-Slack integration.
@@ -243,6 +269,7 @@ class SlackIntegrationApi:
         :type body: SlackIntegrationChannel
         :rtype: SlackIntegrationChannel
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["account_name"] = account_name
 
         kwargs["channel_name"] = channel_name

--- a/src/datadog_api_client/v1/api/snapshots_api.py
+++ b/src/datadog_api_client/v1/api/snapshots_api.py
@@ -93,6 +93,8 @@ class SnapshotsApi:
         event_query: Union[str, UnsetType] = unset,
         graph_def: Union[str, UnsetType] = unset,
         title: Union[str, UnsetType] = unset,
+        height: Union[int, UnsetType] = unset,
+        width: Union[int, UnsetType] = unset,
     ) -> GraphSnapshot:
         """Take graph snapshots.
 
@@ -135,5 +137,11 @@ class SnapshotsApi:
 
         if title is not unset:
             kwargs["title"] = title
+
+        if height is not unset:
+            kwargs["height"] = height
+
+        if width is not unset:
+            kwargs["width"] = width
 
         return self._get_graph_snapshot_endpoint.call_with_http_info(**kwargs)

--- a/src/datadog_api_client/v1/api/snapshots_api.py
+++ b/src/datadog_api_client/v1/api/snapshots_api.py
@@ -1,9 +1,15 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
+from datadog_api_client.model_utils import (
+    UnsetType,
+    unset,
+)
 from datadog_api_client.v1.model.graph_snapshot import GraphSnapshot
 
 
@@ -78,7 +84,16 @@ class SnapshotsApi:
             api_client=api_client,
         )
 
-    def get_graph_snapshot(self, start, end, **kwargs):
+    def get_graph_snapshot(
+        self,
+        start: int,
+        end: int,
+        *,
+        metric_query: Union[str, UnsetType] = unset,
+        event_query: Union[str, UnsetType] = unset,
+        graph_def: Union[str, UnsetType] = unset,
+        title: Union[str, UnsetType] = unset,
+    ) -> GraphSnapshot:
         """Take graph snapshots.
 
         Take graph snapshots.
@@ -104,8 +119,21 @@ class SnapshotsApi:
         :type width: int, optional
         :rtype: GraphSnapshot
         """
+        kwargs: Dict[str, Any] = {}
+        if metric_query is not unset:
+            kwargs["metric_query"] = metric_query
+
         kwargs["start"] = start
 
         kwargs["end"] = end
+
+        if event_query is not unset:
+            kwargs["event_query"] = event_query
+
+        if graph_def is not unset:
+            kwargs["graph_def"] = graph_def
+
+        if title is not unset:
+            kwargs["title"] = title
 
         return self._get_graph_snapshot_endpoint.call_with_http_info(**kwargs)

--- a/src/datadog_api_client/v1/api/synthetics_api.py
+++ b/src/datadog_api_client/v1/api/synthetics_api.py
@@ -1,9 +1,15 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, List, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
+from datadog_api_client.model_utils import (
+    UnsetType,
+    unset,
+)
 from datadog_api_client.v1.model.synthetics_batch_details import SyntheticsBatchDetails
 from datadog_api_client.v1.model.synthetics_locations import SyntheticsLocations
 from datadog_api_client.v1.model.synthetics_private_location_creation_response import (
@@ -730,7 +736,10 @@ class SyntheticsApi:
             api_client=api_client,
         )
 
-    def create_global_variable(self, body, **kwargs):
+    def create_global_variable(
+        self,
+        body: SyntheticsGlobalVariable,
+    ) -> SyntheticsGlobalVariable:
         """Create a global variable.
 
         Create a Synthetics global variable.
@@ -739,11 +748,15 @@ class SyntheticsApi:
         :type body: SyntheticsGlobalVariable
         :rtype: SyntheticsGlobalVariable
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_global_variable_endpoint.call_with_http_info(**kwargs)
 
-    def create_private_location(self, body, **kwargs):
+    def create_private_location(
+        self,
+        body: SyntheticsPrivateLocation,
+    ) -> SyntheticsPrivateLocationCreationResponse:
         """Create a private location.
 
         Create a new Synthetics private location.
@@ -752,11 +765,15 @@ class SyntheticsApi:
         :type body: SyntheticsPrivateLocation
         :rtype: SyntheticsPrivateLocationCreationResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_private_location_endpoint.call_with_http_info(**kwargs)
 
-    def create_synthetics_api_test(self, body, **kwargs):
+    def create_synthetics_api_test(
+        self,
+        body: SyntheticsAPITest,
+    ) -> SyntheticsAPITest:
         """Create an API test.
 
         Create a Synthetic API test.
@@ -765,11 +782,15 @@ class SyntheticsApi:
         :type body: SyntheticsAPITest
         :rtype: SyntheticsAPITest
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_synthetics_api_test_endpoint.call_with_http_info(**kwargs)
 
-    def create_synthetics_browser_test(self, body, **kwargs):
+    def create_synthetics_browser_test(
+        self,
+        body: SyntheticsBrowserTest,
+    ) -> SyntheticsBrowserTest:
         """Create a browser test.
 
         Create a Synthetic browser test.
@@ -778,11 +799,15 @@ class SyntheticsApi:
         :type body: SyntheticsBrowserTest
         :rtype: SyntheticsBrowserTest
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_synthetics_browser_test_endpoint.call_with_http_info(**kwargs)
 
-    def delete_global_variable(self, variable_id, **kwargs):
+    def delete_global_variable(
+        self,
+        variable_id: str,
+    ) -> None:
         """Delete a global variable.
 
         Delete a Synthetics global variable.
@@ -791,11 +816,15 @@ class SyntheticsApi:
         :type variable_id: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["variable_id"] = variable_id
 
         return self._delete_global_variable_endpoint.call_with_http_info(**kwargs)
 
-    def delete_private_location(self, location_id, **kwargs):
+    def delete_private_location(
+        self,
+        location_id: str,
+    ) -> None:
         """Delete a private location.
 
         Delete a Synthetics private location.
@@ -804,11 +833,15 @@ class SyntheticsApi:
         :type location_id: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["location_id"] = location_id
 
         return self._delete_private_location_endpoint.call_with_http_info(**kwargs)
 
-    def delete_tests(self, body, **kwargs):
+    def delete_tests(
+        self,
+        body: SyntheticsDeleteTestsPayload,
+    ) -> SyntheticsDeleteTestsResponse:
         """Delete tests.
 
         Delete multiple Synthetic tests by ID.
@@ -817,11 +850,16 @@ class SyntheticsApi:
         :type body: SyntheticsDeleteTestsPayload
         :rtype: SyntheticsDeleteTestsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._delete_tests_endpoint.call_with_http_info(**kwargs)
 
-    def edit_global_variable(self, variable_id, body, **kwargs):
+    def edit_global_variable(
+        self,
+        variable_id: str,
+        body: SyntheticsGlobalVariable,
+    ) -> SyntheticsGlobalVariable:
         """Edit a global variable.
 
         Edit a Synthetics global variable.
@@ -832,13 +870,17 @@ class SyntheticsApi:
         :type body: SyntheticsGlobalVariable
         :rtype: SyntheticsGlobalVariable
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["variable_id"] = variable_id
 
         kwargs["body"] = body
 
         return self._edit_global_variable_endpoint.call_with_http_info(**kwargs)
 
-    def get_api_test(self, public_id, **kwargs):
+    def get_api_test(
+        self,
+        public_id: str,
+    ) -> SyntheticsAPITest:
         """Get an API test.
 
         Get the detailed configuration associated with
@@ -848,11 +890,19 @@ class SyntheticsApi:
         :type public_id: str
         :rtype: SyntheticsAPITest
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["public_id"] = public_id
 
         return self._get_api_test_endpoint.call_with_http_info(**kwargs)
 
-    def get_api_test_latest_results(self, public_id, **kwargs):
+    def get_api_test_latest_results(
+        self,
+        public_id: str,
+        *,
+        from_ts: Union[int, UnsetType] = unset,
+        to_ts: Union[int, UnsetType] = unset,
+        probe_dc: Union[List[str], UnsetType] = unset,
+    ) -> SyntheticsGetAPITestLatestResultsResponse:
         """Get an API test's latest results summaries.
 
         Get the last 50 test results summaries for a given Synthetics API test.
@@ -867,11 +917,25 @@ class SyntheticsApi:
         :type probe_dc: [str], optional
         :rtype: SyntheticsGetAPITestLatestResultsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["public_id"] = public_id
+
+        if from_ts is not unset:
+            kwargs["from_ts"] = from_ts
+
+        if to_ts is not unset:
+            kwargs["to_ts"] = to_ts
+
+        if probe_dc is not unset:
+            kwargs["probe_dc"] = probe_dc
 
         return self._get_api_test_latest_results_endpoint.call_with_http_info(**kwargs)
 
-    def get_api_test_result(self, public_id, result_id, **kwargs):
+    def get_api_test_result(
+        self,
+        public_id: str,
+        result_id: str,
+    ) -> SyntheticsAPITestResultFull:
         """Get an API test result.
 
         Get a specific full result from a given (API) Synthetic test.
@@ -882,13 +946,17 @@ class SyntheticsApi:
         :type result_id: str
         :rtype: SyntheticsAPITestResultFull
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["public_id"] = public_id
 
         kwargs["result_id"] = result_id
 
         return self._get_api_test_result_endpoint.call_with_http_info(**kwargs)
 
-    def get_browser_test(self, public_id, **kwargs):
+    def get_browser_test(
+        self,
+        public_id: str,
+    ) -> SyntheticsBrowserTest:
         """Get a browser test.
 
         Get the detailed configuration (including steps) associated with
@@ -898,11 +966,19 @@ class SyntheticsApi:
         :type public_id: str
         :rtype: SyntheticsBrowserTest
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["public_id"] = public_id
 
         return self._get_browser_test_endpoint.call_with_http_info(**kwargs)
 
-    def get_browser_test_latest_results(self, public_id, **kwargs):
+    def get_browser_test_latest_results(
+        self,
+        public_id: str,
+        *,
+        from_ts: Union[int, UnsetType] = unset,
+        to_ts: Union[int, UnsetType] = unset,
+        probe_dc: Union[List[str], UnsetType] = unset,
+    ) -> SyntheticsGetBrowserTestLatestResultsResponse:
         """Get a browser test's latest results summaries.
 
         Get the last 50 test results summaries for a given Synthetics Browser test.
@@ -918,11 +994,25 @@ class SyntheticsApi:
         :type probe_dc: [str], optional
         :rtype: SyntheticsGetBrowserTestLatestResultsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["public_id"] = public_id
+
+        if from_ts is not unset:
+            kwargs["from_ts"] = from_ts
+
+        if to_ts is not unset:
+            kwargs["to_ts"] = to_ts
+
+        if probe_dc is not unset:
+            kwargs["probe_dc"] = probe_dc
 
         return self._get_browser_test_latest_results_endpoint.call_with_http_info(**kwargs)
 
-    def get_browser_test_result(self, public_id, result_id, **kwargs):
+    def get_browser_test_result(
+        self,
+        public_id: str,
+        result_id: str,
+    ) -> SyntheticsBrowserTestResultFull:
         """Get a browser test result.
 
         Get a specific full result from a given (browser) Synthetic test.
@@ -934,13 +1024,17 @@ class SyntheticsApi:
         :type result_id: str
         :rtype: SyntheticsBrowserTestResultFull
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["public_id"] = public_id
 
         kwargs["result_id"] = result_id
 
         return self._get_browser_test_result_endpoint.call_with_http_info(**kwargs)
 
-    def get_global_variable(self, variable_id, **kwargs):
+    def get_global_variable(
+        self,
+        variable_id: str,
+    ) -> SyntheticsGlobalVariable:
         """Get a global variable.
 
         Get the detailed configuration of a global variable.
@@ -949,11 +1043,15 @@ class SyntheticsApi:
         :type variable_id: str
         :rtype: SyntheticsGlobalVariable
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["variable_id"] = variable_id
 
         return self._get_global_variable_endpoint.call_with_http_info(**kwargs)
 
-    def get_private_location(self, location_id, **kwargs):
+    def get_private_location(
+        self,
+        location_id: str,
+    ) -> SyntheticsPrivateLocation:
         """Get a private location.
 
         Get a Synthetics private location.
@@ -962,11 +1060,15 @@ class SyntheticsApi:
         :type location_id: str
         :rtype: SyntheticsPrivateLocation
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["location_id"] = location_id
 
         return self._get_private_location_endpoint.call_with_http_info(**kwargs)
 
-    def get_synthetics_ci_batch(self, batch_id, **kwargs):
+    def get_synthetics_ci_batch(
+        self,
+        batch_id: str,
+    ) -> SyntheticsBatchDetails:
         """Get details of batch.
 
         Get a batch's updated details.
@@ -975,11 +1077,15 @@ class SyntheticsApi:
         :type batch_id: str
         :rtype: SyntheticsBatchDetails
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["batch_id"] = batch_id
 
         return self._get_synthetics_ci_batch_endpoint.call_with_http_info(**kwargs)
 
-    def get_test(self, public_id, **kwargs):
+    def get_test(
+        self,
+        public_id: str,
+    ) -> SyntheticsTestDetails:
         """Get a test configuration.
 
         Get the detailed configuration associated with a Synthetics test.
@@ -988,20 +1094,26 @@ class SyntheticsApi:
         :type public_id: str
         :rtype: SyntheticsTestDetails
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["public_id"] = public_id
 
         return self._get_test_endpoint.call_with_http_info(**kwargs)
 
-    def list_global_variables(self, **kwargs):
+    def list_global_variables(
+        self,
+    ) -> SyntheticsListGlobalVariablesResponse:
         """Get all global variables.
 
         Get the list of all Synthetics global variables.
 
         :rtype: SyntheticsListGlobalVariablesResponse
         """
+        kwargs: Dict[str, Any] = {}
         return self._list_global_variables_endpoint.call_with_http_info(**kwargs)
 
-    def list_locations(self, **kwargs):
+    def list_locations(
+        self,
+    ) -> SyntheticsLocations:
         """Get all locations (public and private).
 
         Get the list of public and private locations available for Synthetic
@@ -1009,18 +1121,25 @@ class SyntheticsApi:
 
         :rtype: SyntheticsLocations
         """
+        kwargs: Dict[str, Any] = {}
         return self._list_locations_endpoint.call_with_http_info(**kwargs)
 
-    def list_tests(self, **kwargs):
+    def list_tests(
+        self,
+    ) -> SyntheticsListTestsResponse:
         """Get the list of all tests.
 
         Get the list of all Synthetic tests.
 
         :rtype: SyntheticsListTestsResponse
         """
+        kwargs: Dict[str, Any] = {}
         return self._list_tests_endpoint.call_with_http_info(**kwargs)
 
-    def trigger_ci_tests(self, body, **kwargs):
+    def trigger_ci_tests(
+        self,
+        body: SyntheticsCITestBody,
+    ) -> SyntheticsTriggerCITestsResponse:
         """Trigger tests from CI/CD pipelines.
 
         Trigger a set of Synthetics tests for continuous integration.
@@ -1029,11 +1148,15 @@ class SyntheticsApi:
         :type body: SyntheticsCITestBody
         :rtype: SyntheticsTriggerCITestsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._trigger_ci_tests_endpoint.call_with_http_info(**kwargs)
 
-    def trigger_tests(self, body, **kwargs):
+    def trigger_tests(
+        self,
+        body: SyntheticsTriggerBody,
+    ) -> SyntheticsTriggerCITestsResponse:
         """Trigger Synthetics tests.
 
         Trigger a set of Synthetics tests.
@@ -1042,11 +1165,16 @@ class SyntheticsApi:
         :type body: SyntheticsTriggerBody
         :rtype: SyntheticsTriggerCITestsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._trigger_tests_endpoint.call_with_http_info(**kwargs)
 
-    def update_api_test(self, public_id, body, **kwargs):
+    def update_api_test(
+        self,
+        public_id: str,
+        body: SyntheticsAPITest,
+    ) -> SyntheticsAPITest:
         """Edit an API test.
 
         Edit the configuration of a Synthetic API test.
@@ -1057,13 +1185,18 @@ class SyntheticsApi:
         :type body: SyntheticsAPITest
         :rtype: SyntheticsAPITest
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["public_id"] = public_id
 
         kwargs["body"] = body
 
         return self._update_api_test_endpoint.call_with_http_info(**kwargs)
 
-    def update_browser_test(self, public_id, body, **kwargs):
+    def update_browser_test(
+        self,
+        public_id: str,
+        body: SyntheticsBrowserTest,
+    ) -> SyntheticsBrowserTest:
         """Edit a browser test.
 
         Edit the configuration of a Synthetic browser test.
@@ -1074,13 +1207,18 @@ class SyntheticsApi:
         :type body: SyntheticsBrowserTest
         :rtype: SyntheticsBrowserTest
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["public_id"] = public_id
 
         kwargs["body"] = body
 
         return self._update_browser_test_endpoint.call_with_http_info(**kwargs)
 
-    def update_private_location(self, location_id, body, **kwargs):
+    def update_private_location(
+        self,
+        location_id: str,
+        body: SyntheticsPrivateLocation,
+    ) -> SyntheticsPrivateLocation:
         """Edit a private location.
 
         Edit a Synthetics private location.
@@ -1091,13 +1229,18 @@ class SyntheticsApi:
         :type body: SyntheticsPrivateLocation
         :rtype: SyntheticsPrivateLocation
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["location_id"] = location_id
 
         kwargs["body"] = body
 
         return self._update_private_location_endpoint.call_with_http_info(**kwargs)
 
-    def update_test_pause_status(self, public_id, body, **kwargs):
+    def update_test_pause_status(
+        self,
+        public_id: str,
+        body: SyntheticsUpdateTestPauseStatusPayload,
+    ) -> bool:
         """Pause or start a test.
 
         Pause or start a Synthetics test by changing the status.
@@ -1108,6 +1251,7 @@ class SyntheticsApi:
         :type body: SyntheticsUpdateTestPauseStatusPayload
         :rtype: bool
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["public_id"] = public_id
 
         kwargs["body"] = body

--- a/src/datadog_api_client/v1/api/tags_api.py
+++ b/src/datadog_api_client/v1/api/tags_api.py
@@ -1,9 +1,15 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
+from datadog_api_client.model_utils import (
+    UnsetType,
+    unset,
+)
 from datadog_api_client.v1.model.tag_to_hosts import TagToHosts
 from datadog_api_client.v1.model.host_tags import HostTags
 
@@ -177,7 +183,13 @@ class TagsApi:
             api_client=api_client,
         )
 
-    def create_host_tags(self, host_name, body, **kwargs):
+    def create_host_tags(
+        self,
+        host_name: str,
+        body: HostTags,
+        *,
+        source: Union[str, UnsetType] = unset,
+    ) -> HostTags:
         """Add tags to a host.
 
         This endpoint allows you to add new tags to a host,
@@ -192,13 +204,22 @@ class TagsApi:
         :type source: str, optional
         :rtype: HostTags
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["host_name"] = host_name
+
+        if source is not unset:
+            kwargs["source"] = source
 
         kwargs["body"] = body
 
         return self._create_host_tags_endpoint.call_with_http_info(**kwargs)
 
-    def delete_host_tags(self, host_name, **kwargs):
+    def delete_host_tags(
+        self,
+        host_name: str,
+        *,
+        source: Union[str, UnsetType] = unset,
+    ) -> None:
         """Remove host tags.
 
         This endpoint allows you to remove all user-assigned tags
@@ -211,11 +232,20 @@ class TagsApi:
         :type source: str, optional
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["host_name"] = host_name
+
+        if source is not unset:
+            kwargs["source"] = source
 
         return self._delete_host_tags_endpoint.call_with_http_info(**kwargs)
 
-    def get_host_tags(self, host_name, **kwargs):
+    def get_host_tags(
+        self,
+        host_name: str,
+        *,
+        source: Union[str, UnsetType] = unset,
+    ) -> HostTags:
         """Get host tags.
 
         Return the list of tags that apply to a given host.
@@ -226,11 +256,19 @@ class TagsApi:
         :type source: str, optional
         :rtype: HostTags
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["host_name"] = host_name
+
+        if source is not unset:
+            kwargs["source"] = source
 
         return self._get_host_tags_endpoint.call_with_http_info(**kwargs)
 
-    def list_host_tags(self, **kwargs):
+    def list_host_tags(
+        self,
+        *,
+        source: Union[str, UnsetType] = unset,
+    ) -> TagToHosts:
         """Get Tags.
 
         Return a mapping of tags to hosts for your whole infrastructure.
@@ -239,9 +277,19 @@ class TagsApi:
         :type source: str, optional
         :rtype: TagToHosts
         """
+        kwargs: Dict[str, Any] = {}
+        if source is not unset:
+            kwargs["source"] = source
+
         return self._list_host_tags_endpoint.call_with_http_info(**kwargs)
 
-    def update_host_tags(self, host_name, body, **kwargs):
+    def update_host_tags(
+        self,
+        host_name: str,
+        body: HostTags,
+        *,
+        source: Union[str, UnsetType] = unset,
+    ) -> HostTags:
         """Update host tags.
 
         This endpoint allows you to update/replace all tags in
@@ -256,7 +304,11 @@ class TagsApi:
         :type source: str, optional
         :rtype: HostTags
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["host_name"] = host_name
+
+        if source is not unset:
+            kwargs["source"] = source
 
         kwargs["body"] = body
 

--- a/src/datadog_api_client/v1/api/usage_metering_api.py
+++ b/src/datadog_api_client/v1/api/usage_metering_api.py
@@ -1,11 +1,15 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, List, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.model_utils import (
     datetime,
+    UnsetType,
+    unset,
 )
 from datadog_api_client.v1.model.usage_custom_reports_response import UsageCustomReportsResponse
 from datadog_api_client.v1.model.usage_sort_direction import UsageSortDirection
@@ -1334,7 +1338,14 @@ class UsageMeteringApi:
             api_client=api_client,
         )
 
-    def get_daily_custom_reports(self, **kwargs):
+    def get_daily_custom_reports(
+        self,
+        *,
+        page_size: Union[int, UnsetType] = unset,
+        page_number: Union[int, UnsetType] = unset,
+        sort_dir: Union[UsageSortDirection, UnsetType] = unset,
+        sort: Union[UsageSort, UnsetType] = unset,
+    ) -> UsageCustomReportsResponse:
         """Get the list of available daily custom reports.
 
         Get daily custom reports.
@@ -1349,9 +1360,31 @@ class UsageMeteringApi:
         :type sort: UsageSort, optional
         :rtype: UsageCustomReportsResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if page_size is not unset:
+            kwargs["page_size"] = page_size
+
+        if page_number is not unset:
+            kwargs["page_number"] = page_number
+
+        if sort_dir is not unset:
+            kwargs["sort_dir"] = sort_dir
+
+        if sort is not unset:
+            kwargs["sort"] = sort
+
         return self._get_daily_custom_reports_endpoint.call_with_http_info(**kwargs)
 
-    def get_hourly_usage_attribution(self, start_hr, usage_type, **kwargs):
+    def get_hourly_usage_attribution(
+        self,
+        start_hr: datetime,
+        usage_type: HourlyUsageAttributionUsageType,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+        next_record_id: Union[str, UnsetType] = unset,
+        tag_breakdown_keys: Union[str, UnsetType] = unset,
+        include_descendants: Union[bool, UnsetType] = unset,
+    ) -> HourlyUsageAttributionResponse:
         """Get hourly usage attribution.
 
         Get hourly usage attribution.
@@ -1387,13 +1420,31 @@ class UsageMeteringApi:
         :type include_descendants: bool, optional
         :rtype: HourlyUsageAttributionResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         kwargs["usage_type"] = usage_type
 
+        if next_record_id is not unset:
+            kwargs["next_record_id"] = next_record_id
+
+        if tag_breakdown_keys is not unset:
+            kwargs["tag_breakdown_keys"] = tag_breakdown_keys
+
+        if include_descendants is not unset:
+            kwargs["include_descendants"] = include_descendants
+
         return self._get_hourly_usage_attribution_endpoint.call_with_http_info(**kwargs)
 
-    def get_incident_management(self, start_hr, **kwargs):
+    def get_incident_management(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageIncidentManagementResponse:
         """Get hourly usage for incident management.
 
         Get hourly usage for incident management.
@@ -1405,11 +1456,20 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageIncidentManagementResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_incident_management_endpoint.call_with_http_info(**kwargs)
 
-    def get_ingested_spans(self, start_hr, **kwargs):
+    def get_ingested_spans(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageIngestedSpansResponse:
         """Get hourly usage for ingested spans.
 
         Get hourly usage for ingested spans.
@@ -1421,11 +1481,22 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageIngestedSpansResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_ingested_spans_endpoint.call_with_http_info(**kwargs)
 
-    def get_monthly_custom_reports(self, **kwargs):
+    def get_monthly_custom_reports(
+        self,
+        *,
+        page_size: Union[int, UnsetType] = unset,
+        page_number: Union[int, UnsetType] = unset,
+        sort_dir: Union[UsageSortDirection, UnsetType] = unset,
+        sort: Union[UsageSort, UnsetType] = unset,
+    ) -> UsageCustomReportsResponse:
         """Get the list of available monthly custom reports.
 
         Get monthly custom reports.
@@ -1440,9 +1511,33 @@ class UsageMeteringApi:
         :type sort: UsageSort, optional
         :rtype: UsageCustomReportsResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if page_size is not unset:
+            kwargs["page_size"] = page_size
+
+        if page_number is not unset:
+            kwargs["page_number"] = page_number
+
+        if sort_dir is not unset:
+            kwargs["sort_dir"] = sort_dir
+
+        if sort is not unset:
+            kwargs["sort"] = sort
+
         return self._get_monthly_custom_reports_endpoint.call_with_http_info(**kwargs)
 
-    def get_monthly_usage_attribution(self, start_month, fields, **kwargs):
+    def get_monthly_usage_attribution(
+        self,
+        start_month: datetime,
+        fields: MonthlyUsageAttributionSupportedMetrics,
+        *,
+        end_month: Union[datetime, UnsetType] = unset,
+        sort_direction: Union[UsageSortDirection, UnsetType] = unset,
+        sort_name: Union[MonthlyUsageAttributionSupportedMetrics, UnsetType] = unset,
+        tag_breakdown_keys: Union[str, UnsetType] = unset,
+        next_record_id: Union[str, UnsetType] = unset,
+        include_descendants: Union[bool, UnsetType] = unset,
+    ) -> MonthlyUsageAttributionResponse:
         """Get monthly usage attribution.
 
         Get monthly usage attribution.
@@ -1482,13 +1577,35 @@ class UsageMeteringApi:
         :type include_descendants: bool, optional
         :rtype: MonthlyUsageAttributionResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_month"] = start_month
+
+        if end_month is not unset:
+            kwargs["end_month"] = end_month
 
         kwargs["fields"] = fields
 
+        if sort_direction is not unset:
+            kwargs["sort_direction"] = sort_direction
+
+        if sort_name is not unset:
+            kwargs["sort_name"] = sort_name
+
+        if tag_breakdown_keys is not unset:
+            kwargs["tag_breakdown_keys"] = tag_breakdown_keys
+
+        if next_record_id is not unset:
+            kwargs["next_record_id"] = next_record_id
+
+        if include_descendants is not unset:
+            kwargs["include_descendants"] = include_descendants
+
         return self._get_monthly_usage_attribution_endpoint.call_with_http_info(**kwargs)
 
-    def get_specified_daily_custom_reports(self, report_id, **kwargs):
+    def get_specified_daily_custom_reports(
+        self,
+        report_id: str,
+    ) -> UsageSpecifiedCustomReportsResponse:
         """Get specified daily custom reports.
 
         Get specified daily custom reports.
@@ -1497,11 +1614,15 @@ class UsageMeteringApi:
         :type report_id: str
         :rtype: UsageSpecifiedCustomReportsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["report_id"] = report_id
 
         return self._get_specified_daily_custom_reports_endpoint.call_with_http_info(**kwargs)
 
-    def get_specified_monthly_custom_reports(self, report_id, **kwargs):
+    def get_specified_monthly_custom_reports(
+        self,
+        report_id: str,
+    ) -> UsageSpecifiedCustomReportsResponse:
         """Get specified monthly custom reports.
 
         Get specified monthly custom reports.
@@ -1510,11 +1631,17 @@ class UsageMeteringApi:
         :type report_id: str
         :rtype: UsageSpecifiedCustomReportsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["report_id"] = report_id
 
         return self._get_specified_monthly_custom_reports_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_analyzed_logs(self, start_hr, **kwargs):
+    def get_usage_analyzed_logs(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageAnalyzedLogsResponse:
         """Get hourly usage for analyzed logs.
 
         Get hourly usage for analyzed logs (Security Monitoring).
@@ -1526,11 +1653,26 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageAnalyzedLogsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_analyzed_logs_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_attribution(self, start_month, fields, **kwargs):
+    def get_usage_attribution(
+        self,
+        start_month: datetime,
+        fields: UsageAttributionSupportedMetrics,
+        *,
+        end_month: Union[datetime, UnsetType] = unset,
+        sort_direction: Union[UsageSortDirection, UnsetType] = unset,
+        sort_name: Union[UsageAttributionSort, UnsetType] = unset,
+        include_descendants: Union[bool, UnsetType] = unset,
+        offset: Union[int, UnsetType] = unset,
+        limit: Union[int, UnsetType] = unset,
+    ) -> UsageAttributionResponse:
         """Get usage attribution.
 
         Get usage attribution.
@@ -1554,13 +1696,37 @@ class UsageMeteringApi:
         :type limit: int, optional
         :rtype: UsageAttributionResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_month"] = start_month
 
         kwargs["fields"] = fields
 
+        if end_month is not unset:
+            kwargs["end_month"] = end_month
+
+        if sort_direction is not unset:
+            kwargs["sort_direction"] = sort_direction
+
+        if sort_name is not unset:
+            kwargs["sort_name"] = sort_name
+
+        if include_descendants is not unset:
+            kwargs["include_descendants"] = include_descendants
+
+        if offset is not unset:
+            kwargs["offset"] = offset
+
+        if limit is not unset:
+            kwargs["limit"] = limit
+
         return self._get_usage_attribution_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_audit_logs(self, start_hr, **kwargs):
+    def get_usage_audit_logs(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageAuditLogsResponse:
         """Get hourly usage for audit logs.
 
         Get hourly usage for audit logs.
@@ -1572,11 +1738,19 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageAuditLogsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_audit_logs_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_billable_summary(self, **kwargs):
+    def get_usage_billable_summary(
+        self,
+        *,
+        month: Union[datetime, UnsetType] = unset,
+    ) -> UsageBillableSummaryResponse:
         """Get billable usage across your account.
 
         Get billable usage across your account.
@@ -1585,9 +1759,18 @@ class UsageMeteringApi:
         :type month: datetime, optional
         :rtype: UsageBillableSummaryResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if month is not unset:
+            kwargs["month"] = month
+
         return self._get_usage_billable_summary_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_ci_app(self, start_hr, **kwargs):
+    def get_usage_ci_app(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageCIVisibilityResponse:
         """Get hourly usage for CI Visibility.
 
         Get hourly usage for CI Visibility (Tests, Pipeline, and Spans).
@@ -1599,11 +1782,20 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageCIVisibilityResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_ci_app_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_cloud_security_posture_management(self, start_hr, **kwargs):
+    def get_usage_cloud_security_posture_management(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageCloudSecurityPostureManagementResponse:
         """Get hourly usage for CSPM.
 
         Get hourly usage for Cloud Security Posture Management (CSPM).
@@ -1615,11 +1807,20 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageCloudSecurityPostureManagementResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_cloud_security_posture_management_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_cws(self, start_hr, **kwargs):
+    def get_usage_cws(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageCWSResponse:
         """Get hourly usage for Cloud Workload Security.
 
         Get hourly usage for Cloud Workload Security.
@@ -1631,11 +1832,20 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageCWSResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_cws_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_dbm(self, start_hr, **kwargs):
+    def get_usage_dbm(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageDBMResponse:
         """Get hourly usage for Database Monitoring.
 
         Get hourly usage for Database Monitoring
@@ -1647,11 +1857,20 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageDBMResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_dbm_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_fargate(self, start_hr, **kwargs):
+    def get_usage_fargate(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageFargateResponse:
         """Get hourly usage for Fargate.
 
         Get hourly usage for `Fargate <https://docs.datadoghq.com/integrations/ecs_fargate/>`_.
@@ -1662,11 +1881,20 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageFargateResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_fargate_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_hosts(self, start_hr, **kwargs):
+    def get_usage_hosts(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageHostsResponse:
         """Get hourly usage for hosts and containers.
 
         Get hourly usage for hosts and containers.
@@ -1677,11 +1905,20 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageHostsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_hosts_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_indexed_spans(self, start_hr, **kwargs):
+    def get_usage_indexed_spans(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageIndexedSpansResponse:
         """Get hourly usage for indexed spans.
 
         Get hourly usage for indexed spans.
@@ -1692,11 +1929,20 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageIndexedSpansResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_indexed_spans_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_internet_of_things(self, start_hr, **kwargs):
+    def get_usage_internet_of_things(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageIoTResponse:
         """Get hourly usage for IoT.
 
         Get hourly usage for IoT.
@@ -1708,11 +1954,20 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageIoTResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_internet_of_things_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_lambda(self, start_hr, **kwargs):
+    def get_usage_lambda(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageLambdaResponse:
         """Get hourly usage for Lambda.
 
         Get hourly usage for lambda.
@@ -1723,11 +1978,20 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageLambdaResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_lambda_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_logs(self, start_hr, **kwargs):
+    def get_usage_logs(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageLogsResponse:
         """Get hourly usage for Logs.
 
         Get hourly usage for logs.
@@ -1738,11 +2002,21 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageLogsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_logs_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_logs_by_index(self, start_hr, **kwargs):
+    def get_usage_logs_by_index(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+        index_name: Union[List[str], UnsetType] = unset,
+    ) -> UsageLogsByIndexResponse:
         """Get hourly usage for Logs by Index.
 
         Get hourly usage for logs by index.
@@ -1755,11 +2029,23 @@ class UsageMeteringApi:
         :type index_name: [str], optional
         :rtype: UsageLogsByIndexResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
+
+        if index_name is not unset:
+            kwargs["index_name"] = index_name
 
         return self._get_usage_logs_by_index_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_logs_by_retention(self, start_hr, **kwargs):
+    def get_usage_logs_by_retention(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageLogsByRetentionResponse:
         """Get hourly logs usage by retention.
 
         Get hourly usage for indexed logs by retention period.
@@ -1771,11 +2057,20 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageLogsByRetentionResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_logs_by_retention_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_network_flows(self, start_hr, **kwargs):
+    def get_usage_network_flows(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageNetworkFlowsResponse:
         """Get hourly usage for Network Flows.
 
         Get hourly usage for network flows.
@@ -1787,11 +2082,20 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageNetworkFlowsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_network_flows_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_network_hosts(self, start_hr, **kwargs):
+    def get_usage_network_hosts(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageNetworkHostsResponse:
         """Get hourly usage for Network Hosts.
 
         Get hourly usage for network hosts.
@@ -1802,11 +2106,20 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageNetworkHostsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_network_hosts_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_online_archive(self, start_hr, **kwargs):
+    def get_usage_online_archive(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageOnlineArchiveResponse:
         """Get hourly usage for Online Archive.
 
         Get hourly usage for Online Archive.
@@ -1818,11 +2131,20 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageOnlineArchiveResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_online_archive_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_profiling(self, start_hr, **kwargs):
+    def get_usage_profiling(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageProfilingResponse:
         """Get hourly usage for profiled hosts.
 
         Get hourly usage for profiled hosts.
@@ -1834,11 +2156,21 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageProfilingResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_profiling_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_rum_sessions(self, start_hr, **kwargs):
+    def get_usage_rum_sessions(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+        type: Union[str, UnsetType] = unset,
+    ) -> UsageRumSessionsResponse:
         """Get hourly usage for RUM Sessions.
 
         Get hourly usage for `RUM <https://docs.datadoghq.com/real_user_monitoring/>`_ Sessions.
@@ -1851,11 +2183,23 @@ class UsageMeteringApi:
         :type type: str, optional
         :rtype: UsageRumSessionsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
+
+        if type is not unset:
+            kwargs["type"] = type
 
         return self._get_usage_rum_sessions_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_rum_units(self, start_hr, **kwargs):
+    def get_usage_rum_units(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageRumUnitsResponse:
         """Get hourly usage for RUM Units.
 
         Get hourly usage for `RUM <https://docs.datadoghq.com/real_user_monitoring/>`_ Units.
@@ -1866,11 +2210,20 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageRumUnitsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_rum_units_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_sds(self, start_hr, **kwargs):
+    def get_usage_sds(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageSDSResponse:
         """Get hourly usage for Sensitive Data Scanner.
 
         Get hourly usage for Sensitive Data Scanner.
@@ -1882,11 +2235,20 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageSDSResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_sds_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_snmp(self, start_hr, **kwargs):
+    def get_usage_snmp(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageSNMPResponse:
         """Get hourly usage for SNMP devices.
 
         Get hourly usage for SNMP devices.
@@ -1898,11 +2260,21 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageSNMPResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_snmp_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_summary(self, start_month, **kwargs):
+    def get_usage_summary(
+        self,
+        start_month: datetime,
+        *,
+        end_month: Union[datetime, UnsetType] = unset,
+        include_org_details: Union[bool, UnsetType] = unset,
+    ) -> UsageSummaryResponse:
         """Get usage across your multi-org account.
 
         Get usage across your multi-org account. You must have the multi-org feature enabled.
@@ -1916,11 +2288,23 @@ class UsageMeteringApi:
         :type include_org_details: bool, optional
         :rtype: UsageSummaryResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_month"] = start_month
+
+        if end_month is not unset:
+            kwargs["end_month"] = end_month
+
+        if include_org_details is not unset:
+            kwargs["include_org_details"] = include_org_details
 
         return self._get_usage_summary_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_synthetics(self, start_hr, **kwargs):
+    def get_usage_synthetics(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageSyntheticsResponse:
         """Get hourly usage for Synthetics Checks.
 
         Get hourly usage for `Synthetics checks <https://docs.datadoghq.com/synthetics/>`_.
@@ -1931,11 +2315,20 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageSyntheticsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_synthetics_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_synthetics_api(self, start_hr, **kwargs):
+    def get_usage_synthetics_api(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageSyntheticsAPIResponse:
         """Get hourly usage for Synthetics API Checks.
 
         Get hourly usage for `synthetics API checks <https://docs.datadoghq.com/synthetics/>`_.
@@ -1946,11 +2339,20 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageSyntheticsAPIResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_synthetics_api_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_synthetics_browser(self, start_hr, **kwargs):
+    def get_usage_synthetics_browser(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageSyntheticsBrowserResponse:
         """Get hourly usage for Synthetics Browser Checks.
 
         Get hourly usage for synthetics browser checks.
@@ -1961,11 +2363,20 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageSyntheticsBrowserResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_synthetics_browser_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_timeseries(self, start_hr, **kwargs):
+    def get_usage_timeseries(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageTimeseriesResponse:
         """Get hourly usage for custom metrics.
 
         Get hourly usage for `custom metrics <https://docs.datadoghq.com/developers/metrics/custom_metrics/>`_.
@@ -1976,11 +2387,23 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageTimeseriesResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_timeseries_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_top_avg_metrics(self, **kwargs):
+    def get_usage_top_avg_metrics(
+        self,
+        *,
+        month: Union[datetime, UnsetType] = unset,
+        day: Union[datetime, UnsetType] = unset,
+        names: Union[List[str], UnsetType] = unset,
+        limit: Union[int, UnsetType] = unset,
+        next_record_id: Union[str, UnsetType] = unset,
+    ) -> UsageTopAvgMetricsResponse:
         """Get all custom metrics by hourly average.
 
         Get all `custom metrics <https://docs.datadoghq.com/developers/metrics/custom_metrics/>`_ by hourly average. Use the month parameter to get a month-to-date data resolution or use the day parameter to get a daily resolution. One of the two is required, and only one of the two is allowed.
@@ -1997,4 +2420,20 @@ class UsageMeteringApi:
         :type next_record_id: str, optional
         :rtype: UsageTopAvgMetricsResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if month is not unset:
+            kwargs["month"] = month
+
+        if day is not unset:
+            kwargs["day"] = day
+
+        if names is not unset:
+            kwargs["names"] = names
+
+        if limit is not unset:
+            kwargs["limit"] = limit
+
+        if next_record_id is not unset:
+            kwargs["next_record_id"] = next_record_id
+
         return self._get_usage_top_avg_metrics_endpoint.call_with_http_info(**kwargs)

--- a/src/datadog_api_client/v1/api/users_api.py
+++ b/src/datadog_api_client/v1/api/users_api.py
@@ -1,7 +1,9 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.v1.model.user_list_response import UserListResponse
@@ -136,7 +138,10 @@ class UsersApi:
             api_client=api_client,
         )
 
-    def create_user(self, body, **kwargs):
+    def create_user(
+        self,
+        body: User,
+    ) -> UserResponse:
         """Create a user.
 
         Create a user for your organization.
@@ -148,11 +153,15 @@ class UsersApi:
         :type body: User
         :rtype: UserResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_user_endpoint.call_with_http_info(**kwargs)
 
-    def disable_user(self, user_handle, **kwargs):
+    def disable_user(
+        self,
+        user_handle: str,
+    ) -> UserDisableResponse:
         """Disable a user.
 
         Delete a user from an organization.
@@ -164,11 +173,15 @@ class UsersApi:
         :type user_handle: str
         :rtype: UserDisableResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["user_handle"] = user_handle
 
         return self._disable_user_endpoint.call_with_http_info(**kwargs)
 
-    def get_user(self, user_handle, **kwargs):
+    def get_user(
+        self,
+        user_handle: str,
+    ) -> UserResponse:
         """Get user details.
 
         Get a user's details.
@@ -177,20 +190,28 @@ class UsersApi:
         :type user_handle: str
         :rtype: UserResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["user_handle"] = user_handle
 
         return self._get_user_endpoint.call_with_http_info(**kwargs)
 
-    def list_users(self, **kwargs):
+    def list_users(
+        self,
+    ) -> UserListResponse:
         """List all users.
 
         List all users for your organization.
 
         :rtype: UserListResponse
         """
+        kwargs: Dict[str, Any] = {}
         return self._list_users_endpoint.call_with_http_info(**kwargs)
 
-    def update_user(self, user_handle, body, **kwargs):
+    def update_user(
+        self,
+        user_handle: str,
+        body: User,
+    ) -> UserResponse:
         """Update a user.
 
         Update a user information.
@@ -203,6 +224,7 @@ class UsersApi:
         :type body: User
         :rtype: UserResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["user_handle"] = user_handle
 
         kwargs["body"] = body

--- a/src/datadog_api_client/v1/api/webhooks_integration_api.py
+++ b/src/datadog_api_client/v1/api/webhooks_integration_api.py
@@ -1,7 +1,9 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.v1.model.webhooks_integration_custom_variable_response import (
@@ -223,7 +225,10 @@ class WebhooksIntegrationApi:
             api_client=api_client,
         )
 
-    def create_webhooks_integration(self, body, **kwargs):
+    def create_webhooks_integration(
+        self,
+        body: WebhooksIntegration,
+    ) -> WebhooksIntegration:
         """Create a webhooks integration.
 
         Creates an endpoint with the name ``<WEBHOOK_NAME>``.
@@ -232,11 +237,15 @@ class WebhooksIntegrationApi:
         :type body: WebhooksIntegration
         :rtype: WebhooksIntegration
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_webhooks_integration_endpoint.call_with_http_info(**kwargs)
 
-    def create_webhooks_integration_custom_variable(self, body, **kwargs):
+    def create_webhooks_integration_custom_variable(
+        self,
+        body: WebhooksIntegrationCustomVariable,
+    ) -> WebhooksIntegrationCustomVariableResponse:
         """Create a custom variable.
 
         Creates an endpoint with the name ``<CUSTOM_VARIABLE_NAME>``.
@@ -245,11 +254,15 @@ class WebhooksIntegrationApi:
         :type body: WebhooksIntegrationCustomVariable
         :rtype: WebhooksIntegrationCustomVariableResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_webhooks_integration_custom_variable_endpoint.call_with_http_info(**kwargs)
 
-    def delete_webhooks_integration(self, webhook_name, **kwargs):
+    def delete_webhooks_integration(
+        self,
+        webhook_name: str,
+    ) -> None:
         """Delete a webhook.
 
         Deletes the endpoint with the name ``<WEBHOOK NAME>``.
@@ -258,11 +271,15 @@ class WebhooksIntegrationApi:
         :type webhook_name: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["webhook_name"] = webhook_name
 
         return self._delete_webhooks_integration_endpoint.call_with_http_info(**kwargs)
 
-    def delete_webhooks_integration_custom_variable(self, custom_variable_name, **kwargs):
+    def delete_webhooks_integration_custom_variable(
+        self,
+        custom_variable_name: str,
+    ) -> None:
         """Delete a custom variable.
 
         Deletes the endpoint with the name ``<CUSTOM_VARIABLE_NAME>``.
@@ -271,11 +288,15 @@ class WebhooksIntegrationApi:
         :type custom_variable_name: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["custom_variable_name"] = custom_variable_name
 
         return self._delete_webhooks_integration_custom_variable_endpoint.call_with_http_info(**kwargs)
 
-    def get_webhooks_integration(self, webhook_name, **kwargs):
+    def get_webhooks_integration(
+        self,
+        webhook_name: str,
+    ) -> WebhooksIntegration:
         """Get a webhook integration.
 
         Gets the content of the webhook with the name ``<WEBHOOK_NAME>``.
@@ -284,11 +305,15 @@ class WebhooksIntegrationApi:
         :type webhook_name: str
         :rtype: WebhooksIntegration
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["webhook_name"] = webhook_name
 
         return self._get_webhooks_integration_endpoint.call_with_http_info(**kwargs)
 
-    def get_webhooks_integration_custom_variable(self, custom_variable_name, **kwargs):
+    def get_webhooks_integration_custom_variable(
+        self,
+        custom_variable_name: str,
+    ) -> WebhooksIntegrationCustomVariableResponse:
         """Get a custom variable.
 
         Shows the content of the custom variable with the name ``<CUSTOM_VARIABLE_NAME>``.
@@ -300,11 +325,16 @@ class WebhooksIntegrationApi:
         :type custom_variable_name: str
         :rtype: WebhooksIntegrationCustomVariableResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["custom_variable_name"] = custom_variable_name
 
         return self._get_webhooks_integration_custom_variable_endpoint.call_with_http_info(**kwargs)
 
-    def update_webhooks_integration(self, webhook_name, body, **kwargs):
+    def update_webhooks_integration(
+        self,
+        webhook_name: str,
+        body: WebhooksIntegrationUpdateRequest,
+    ) -> WebhooksIntegration:
         """Update a webhook.
 
         Updates the endpoint with the name ``<WEBHOOK_NAME>``.
@@ -315,13 +345,18 @@ class WebhooksIntegrationApi:
         :type body: WebhooksIntegrationUpdateRequest
         :rtype: WebhooksIntegration
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["webhook_name"] = webhook_name
 
         kwargs["body"] = body
 
         return self._update_webhooks_integration_endpoint.call_with_http_info(**kwargs)
 
-    def update_webhooks_integration_custom_variable(self, custom_variable_name, body, **kwargs):
+    def update_webhooks_integration_custom_variable(
+        self,
+        custom_variable_name: str,
+        body: WebhooksIntegrationCustomVariableUpdateRequest,
+    ) -> WebhooksIntegrationCustomVariableResponse:
         """Update a custom variable.
 
         Updates the endpoint with the name ``<CUSTOM_VARIABLE_NAME>``.
@@ -332,6 +367,7 @@ class WebhooksIntegrationApi:
         :type body: WebhooksIntegrationCustomVariableUpdateRequest
         :rtype: WebhooksIntegrationCustomVariableResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["custom_variable_name"] = custom_variable_name
 
         kwargs["body"] = body

--- a/src/datadog_api_client/v2/api/audit_api.py
+++ b/src/datadog_api_client/v2/api/audit_api.py
@@ -1,13 +1,17 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.model_utils import (
     datetime,
     set_attribute_from_path,
     get_attribute_from_path,
+    UnsetType,
+    unset,
 )
 from datadog_api_client.v2.model.audit_logs_events_response import AuditLogsEventsResponse
 from datadog_api_client.v2.model.audit_logs_sort import AuditLogsSort
@@ -96,7 +100,16 @@ class AuditApi:
             api_client=api_client,
         )
 
-    def list_audit_logs(self, **kwargs):
+    def list_audit_logs(
+        self,
+        *,
+        filter_query: Union[str, UnsetType] = unset,
+        filter_from: Union[datetime, UnsetType] = unset,
+        filter_to: Union[datetime, UnsetType] = unset,
+        sort: Union[AuditLogsSort, UnsetType] = unset,
+        page_cursor: Union[str, UnsetType] = unset,
+        page_limit: Union[int, UnsetType] = unset,
+    ) -> AuditLogsEventsResponse:
         """Get a list of Audit Logs events.
 
         List endpoint returns events that match a Audit Logs search query.
@@ -118,6 +131,25 @@ class AuditApi:
         :type page_limit: int, optional
         :rtype: AuditLogsEventsResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if filter_query is not unset:
+            kwargs["filter_query"] = filter_query
+
+        if filter_from is not unset:
+            kwargs["filter_from"] = filter_from
+
+        if filter_to is not unset:
+            kwargs["filter_to"] = filter_to
+
+        if sort is not unset:
+            kwargs["sort"] = sort
+
+        if page_cursor is not unset:
+            kwargs["page_cursor"] = page_cursor
+
+        if page_limit is not unset:
+            kwargs["page_limit"] = page_limit
+
         return self._list_audit_logs_endpoint.call_with_http_info(**kwargs)
 
     def list_audit_logs_with_pagination(self, **kwargs):
@@ -154,7 +186,11 @@ class AuditApi:
                 kwargs, "page_cursor", get_attribute_from_path(response, "meta.page.after"), endpoint.params_map
             )
 
-    def search_audit_logs(self, **kwargs):
+    def search_audit_logs(
+        self,
+        *,
+        body: Union[AuditLogsSearchEventsRequest, UnsetType] = unset,
+    ) -> AuditLogsEventsResponse:
         """Search Audit Logs events.
 
         List endpoint returns Audit Logs events that match an Audit search query.
@@ -165,6 +201,10 @@ class AuditApi:
         :type body: AuditLogsSearchEventsRequest, optional
         :rtype: AuditLogsEventsResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if body is not unset:
+            kwargs["body"] = body
+
         return self._search_audit_logs_endpoint.call_with_http_info(**kwargs)
 
     def search_audit_logs_with_pagination(self, **kwargs):

--- a/src/datadog_api_client/v2/api/authn_mappings_api.py
+++ b/src/datadog_api_client/v2/api/authn_mappings_api.py
@@ -1,9 +1,15 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
+from datadog_api_client.model_utils import (
+    UnsetType,
+    unset,
+)
 from datadog_api_client.v2.model.authn_mappings_response import AuthNMappingsResponse
 from datadog_api_client.v2.model.authn_mappings_sort import AuthNMappingsSort
 from datadog_api_client.v2.model.authn_mapping_response import AuthNMappingResponse
@@ -160,7 +166,10 @@ class AuthNMappingsApi:
             api_client=api_client,
         )
 
-    def create_authn_mapping(self, body, **kwargs):
+    def create_authn_mapping(
+        self,
+        body: AuthNMappingCreateRequest,
+    ) -> AuthNMappingResponse:
         """Create an AuthN Mapping.
 
         Create an AuthN Mapping.
@@ -168,11 +177,15 @@ class AuthNMappingsApi:
         :type body: AuthNMappingCreateRequest
         :rtype: AuthNMappingResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_authn_mapping_endpoint.call_with_http_info(**kwargs)
 
-    def delete_authn_mapping(self, authn_mapping_id, **kwargs):
+    def delete_authn_mapping(
+        self,
+        authn_mapping_id: str,
+    ) -> None:
         """Delete an AuthN Mapping.
 
         Delete an AuthN Mapping specified by AuthN Mapping UUID.
@@ -181,11 +194,15 @@ class AuthNMappingsApi:
         :type authn_mapping_id: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["authn_mapping_id"] = authn_mapping_id
 
         return self._delete_authn_mapping_endpoint.call_with_http_info(**kwargs)
 
-    def get_authn_mapping(self, authn_mapping_id, **kwargs):
+    def get_authn_mapping(
+        self,
+        authn_mapping_id: str,
+    ) -> AuthNMappingResponse:
         """Get an AuthN Mapping by UUID.
 
         Get an AuthN Mapping specified by the AuthN Mapping UUID.
@@ -194,11 +211,19 @@ class AuthNMappingsApi:
         :type authn_mapping_id: str
         :rtype: AuthNMappingResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["authn_mapping_id"] = authn_mapping_id
 
         return self._get_authn_mapping_endpoint.call_with_http_info(**kwargs)
 
-    def list_authn_mappings(self, **kwargs):
+    def list_authn_mappings(
+        self,
+        *,
+        page_size: Union[int, UnsetType] = unset,
+        page_number: Union[int, UnsetType] = unset,
+        sort: Union[AuthNMappingsSort, UnsetType] = unset,
+        filter: Union[str, UnsetType] = unset,
+    ) -> AuthNMappingsResponse:
         """List all AuthN Mappings.
 
         List all AuthN Mappings in the org.
@@ -213,9 +238,26 @@ class AuthNMappingsApi:
         :type filter: str, optional
         :rtype: AuthNMappingsResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if page_size is not unset:
+            kwargs["page_size"] = page_size
+
+        if page_number is not unset:
+            kwargs["page_number"] = page_number
+
+        if sort is not unset:
+            kwargs["sort"] = sort
+
+        if filter is not unset:
+            kwargs["filter"] = filter
+
         return self._list_authn_mappings_endpoint.call_with_http_info(**kwargs)
 
-    def update_authn_mapping(self, authn_mapping_id, body, **kwargs):
+    def update_authn_mapping(
+        self,
+        authn_mapping_id: str,
+        body: AuthNMappingUpdateRequest,
+    ) -> AuthNMappingResponse:
         """Edit an AuthN Mapping.
 
         Edit an AuthN Mapping.
@@ -225,6 +267,7 @@ class AuthNMappingsApi:
         :type body: AuthNMappingUpdateRequest
         :rtype: AuthNMappingResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["authn_mapping_id"] = authn_mapping_id
 
         kwargs["body"] = body

--- a/src/datadog_api_client/v2/api/cloud_workload_security_api.py
+++ b/src/datadog_api_client/v2/api/cloud_workload_security_api.py
@@ -1,7 +1,9 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.model_utils import (
@@ -165,7 +167,10 @@ class CloudWorkloadSecurityApi:
             api_client=api_client,
         )
 
-    def create_cloud_workload_security_agent_rule(self, body, **kwargs):
+    def create_cloud_workload_security_agent_rule(
+        self,
+        body: CloudWorkloadSecurityAgentRuleCreateRequest,
+    ) -> CloudWorkloadSecurityAgentRuleResponse:
         """Create a Cloud Workload Security Agent rule.
 
         Create a new Agent rule with the given parameters.
@@ -174,11 +179,15 @@ class CloudWorkloadSecurityApi:
         :type body: CloudWorkloadSecurityAgentRuleCreateRequest
         :rtype: CloudWorkloadSecurityAgentRuleResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_cloud_workload_security_agent_rule_endpoint.call_with_http_info(**kwargs)
 
-    def delete_cloud_workload_security_agent_rule(self, agent_rule_id, **kwargs):
+    def delete_cloud_workload_security_agent_rule(
+        self,
+        agent_rule_id: str,
+    ) -> None:
         """Delete a Cloud Workload Security Agent rule.
 
         Delete a specific Agent rule.
@@ -187,11 +196,14 @@ class CloudWorkloadSecurityApi:
         :type agent_rule_id: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["agent_rule_id"] = agent_rule_id
 
         return self._delete_cloud_workload_security_agent_rule_endpoint.call_with_http_info(**kwargs)
 
-    def download_cloud_workload_policy_file(self, **kwargs):
+    def download_cloud_workload_policy_file(
+        self,
+    ) -> file_type:
         """Get the latest Cloud Workload Security policy.
 
         The download endpoint generates a Cloud Workload Security policy file from your currently active
@@ -200,9 +212,13 @@ class CloudWorkloadSecurityApi:
 
         :rtype: file_type
         """
+        kwargs: Dict[str, Any] = {}
         return self._download_cloud_workload_policy_file_endpoint.call_with_http_info(**kwargs)
 
-    def get_cloud_workload_security_agent_rule(self, agent_rule_id, **kwargs):
+    def get_cloud_workload_security_agent_rule(
+        self,
+        agent_rule_id: str,
+    ) -> CloudWorkloadSecurityAgentRuleResponse:
         """Get a Cloud Workload Security Agent rule.
 
         Get the details of a specific Agent rule.
@@ -211,20 +227,28 @@ class CloudWorkloadSecurityApi:
         :type agent_rule_id: str
         :rtype: CloudWorkloadSecurityAgentRuleResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["agent_rule_id"] = agent_rule_id
 
         return self._get_cloud_workload_security_agent_rule_endpoint.call_with_http_info(**kwargs)
 
-    def list_cloud_workload_security_agent_rules(self, **kwargs):
+    def list_cloud_workload_security_agent_rules(
+        self,
+    ) -> CloudWorkloadSecurityAgentRulesListResponse:
         """Get all Cloud Workload Security Agent rules.
 
         Get the list of Agent rules.
 
         :rtype: CloudWorkloadSecurityAgentRulesListResponse
         """
+        kwargs: Dict[str, Any] = {}
         return self._list_cloud_workload_security_agent_rules_endpoint.call_with_http_info(**kwargs)
 
-    def update_cloud_workload_security_agent_rule(self, agent_rule_id, body, **kwargs):
+    def update_cloud_workload_security_agent_rule(
+        self,
+        agent_rule_id: str,
+        body: CloudWorkloadSecurityAgentRuleUpdateRequest,
+    ) -> CloudWorkloadSecurityAgentRuleResponse:
         """Update a Cloud Workload Security Agent rule.
 
         Update a specific Agent rule.
@@ -236,6 +260,7 @@ class CloudWorkloadSecurityApi:
         :type body: CloudWorkloadSecurityAgentRuleUpdateRequest
         :rtype: CloudWorkloadSecurityAgentRuleResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["agent_rule_id"] = agent_rule_id
 
         kwargs["body"] = body

--- a/src/datadog_api_client/v2/api/dashboard_lists_api.py
+++ b/src/datadog_api_client/v2/api/dashboard_lists_api.py
@@ -1,7 +1,9 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.v2.model.dashboard_list_delete_items_response import DashboardListDeleteItemsResponse
@@ -131,7 +133,11 @@ class DashboardListsApi:
             api_client=api_client,
         )
 
-    def create_dashboard_list_items(self, dashboard_list_id, body, **kwargs):
+    def create_dashboard_list_items(
+        self,
+        dashboard_list_id: int,
+        body: DashboardListAddItemsRequest,
+    ) -> DashboardListAddItemsResponse:
         """Add Items to a Dashboard List.
 
         Add dashboards to an existing dashboard list.
@@ -142,13 +148,18 @@ class DashboardListsApi:
         :type body: DashboardListAddItemsRequest
         :rtype: DashboardListAddItemsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["dashboard_list_id"] = dashboard_list_id
 
         kwargs["body"] = body
 
         return self._create_dashboard_list_items_endpoint.call_with_http_info(**kwargs)
 
-    def delete_dashboard_list_items(self, dashboard_list_id, body, **kwargs):
+    def delete_dashboard_list_items(
+        self,
+        dashboard_list_id: int,
+        body: DashboardListDeleteItemsRequest,
+    ) -> DashboardListDeleteItemsResponse:
         """Delete items from a dashboard list.
 
         Delete dashboards from an existing dashboard list.
@@ -159,13 +170,17 @@ class DashboardListsApi:
         :type body: DashboardListDeleteItemsRequest
         :rtype: DashboardListDeleteItemsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["dashboard_list_id"] = dashboard_list_id
 
         kwargs["body"] = body
 
         return self._delete_dashboard_list_items_endpoint.call_with_http_info(**kwargs)
 
-    def get_dashboard_list_items(self, dashboard_list_id, **kwargs):
+    def get_dashboard_list_items(
+        self,
+        dashboard_list_id: int,
+    ) -> DashboardListItems:
         """Get items of a Dashboard List.
 
         Fetch the dashboard list’s dashboard definitions.
@@ -174,11 +189,16 @@ class DashboardListsApi:
         :type dashboard_list_id: int
         :rtype: DashboardListItems
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["dashboard_list_id"] = dashboard_list_id
 
         return self._get_dashboard_list_items_endpoint.call_with_http_info(**kwargs)
 
-    def update_dashboard_list_items(self, dashboard_list_id, body, **kwargs):
+    def update_dashboard_list_items(
+        self,
+        dashboard_list_id: int,
+        body: DashboardListUpdateItemsRequest,
+    ) -> DashboardListUpdateItemsResponse:
         """Update items of a dashboard list.
 
         Update dashboards of an existing dashboard list.
@@ -189,6 +209,7 @@ class DashboardListsApi:
         :type body: DashboardListUpdateItemsRequest
         :rtype: DashboardListUpdateItemsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["dashboard_list_id"] = dashboard_list_id
 
         kwargs["body"] = body

--- a/src/datadog_api_client/v2/api/incident_services_api.py
+++ b/src/datadog_api_client/v2/api/incident_services_api.py
@@ -1,9 +1,15 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
+from datadog_api_client.model_utils import (
+    UnsetType,
+    unset,
+)
 from datadog_api_client.v2.model.incident_services_response import IncidentServicesResponse
 from datadog_api_client.v2.model.incident_related_object import IncidentRelatedObject
 from datadog_api_client.v2.model.incident_service_response import IncidentServiceResponse
@@ -163,7 +169,10 @@ class IncidentServicesApi:
             api_client=api_client,
         )
 
-    def create_incident_service(self, body, **kwargs):
+    def create_incident_service(
+        self,
+        body: IncidentServiceCreateRequest,
+    ) -> IncidentServiceResponse:
         """Create a new incident service.
 
         Creates a new incident service.
@@ -172,11 +181,15 @@ class IncidentServicesApi:
         :type body: IncidentServiceCreateRequest
         :rtype: IncidentServiceResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_incident_service_endpoint.call_with_http_info(**kwargs)
 
-    def delete_incident_service(self, service_id, **kwargs):
+    def delete_incident_service(
+        self,
+        service_id: str,
+    ) -> None:
         """Delete an existing incident service.
 
         Deletes an existing incident service.
@@ -185,11 +198,17 @@ class IncidentServicesApi:
         :type service_id: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["service_id"] = service_id
 
         return self._delete_incident_service_endpoint.call_with_http_info(**kwargs)
 
-    def get_incident_service(self, service_id, **kwargs):
+    def get_incident_service(
+        self,
+        service_id: str,
+        *,
+        include: Union[IncidentRelatedObject, UnsetType] = unset,
+    ) -> IncidentServiceResponse:
         """Get details of an incident service.
 
         Get details of an incident service. If the ``include[users]`` query parameter is provided,
@@ -201,11 +220,22 @@ class IncidentServicesApi:
         :type include: IncidentRelatedObject, optional
         :rtype: IncidentServiceResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["service_id"] = service_id
+
+        if include is not unset:
+            kwargs["include"] = include
 
         return self._get_incident_service_endpoint.call_with_http_info(**kwargs)
 
-    def list_incident_services(self, **kwargs):
+    def list_incident_services(
+        self,
+        *,
+        include: Union[IncidentRelatedObject, UnsetType] = unset,
+        page_size: Union[int, UnsetType] = unset,
+        page_offset: Union[int, UnsetType] = unset,
+        filter: Union[str, UnsetType] = unset,
+    ) -> IncidentServicesResponse:
         """Get a list of all incident services.
 
         Get all incident services uploaded for the requesting user's organization. If the ``include[users]`` query parameter is provided, the included attribute will contain the users related to these incident services.
@@ -220,9 +250,26 @@ class IncidentServicesApi:
         :type filter: str, optional
         :rtype: IncidentServicesResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if include is not unset:
+            kwargs["include"] = include
+
+        if page_size is not unset:
+            kwargs["page_size"] = page_size
+
+        if page_offset is not unset:
+            kwargs["page_offset"] = page_offset
+
+        if filter is not unset:
+            kwargs["filter"] = filter
+
         return self._list_incident_services_endpoint.call_with_http_info(**kwargs)
 
-    def update_incident_service(self, service_id, body, **kwargs):
+    def update_incident_service(
+        self,
+        service_id: str,
+        body: IncidentServiceUpdateRequest,
+    ) -> IncidentServiceResponse:
         """Update an existing incident service.
 
         Updates an existing incident service. Only provide the attributes which should be updated as this request is a partial update.
@@ -233,6 +280,7 @@ class IncidentServicesApi:
         :type body: IncidentServiceUpdateRequest
         :rtype: IncidentServiceResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["service_id"] = service_id
 
         kwargs["body"] = body

--- a/src/datadog_api_client/v2/api/incident_teams_api.py
+++ b/src/datadog_api_client/v2/api/incident_teams_api.py
@@ -1,9 +1,15 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
+from datadog_api_client.model_utils import (
+    UnsetType,
+    unset,
+)
 from datadog_api_client.v2.model.incident_teams_response import IncidentTeamsResponse
 from datadog_api_client.v2.model.incident_related_object import IncidentRelatedObject
 from datadog_api_client.v2.model.incident_team_response import IncidentTeamResponse
@@ -163,7 +169,10 @@ class IncidentTeamsApi:
             api_client=api_client,
         )
 
-    def create_incident_team(self, body, **kwargs):
+    def create_incident_team(
+        self,
+        body: IncidentTeamCreateRequest,
+    ) -> IncidentTeamResponse:
         """Create a new incident team.
 
         Creates a new incident team.
@@ -172,11 +181,15 @@ class IncidentTeamsApi:
         :type body: IncidentTeamCreateRequest
         :rtype: IncidentTeamResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_incident_team_endpoint.call_with_http_info(**kwargs)
 
-    def delete_incident_team(self, team_id, **kwargs):
+    def delete_incident_team(
+        self,
+        team_id: str,
+    ) -> None:
         """Delete an existing incident team.
 
         Deletes an existing incident team.
@@ -185,11 +198,17 @@ class IncidentTeamsApi:
         :type team_id: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["team_id"] = team_id
 
         return self._delete_incident_team_endpoint.call_with_http_info(**kwargs)
 
-    def get_incident_team(self, team_id, **kwargs):
+    def get_incident_team(
+        self,
+        team_id: str,
+        *,
+        include: Union[IncidentRelatedObject, UnsetType] = unset,
+    ) -> IncidentTeamResponse:
         """Get details of an incident team.
 
         Get details of an incident team. If the ``include[users]`` query parameter is provided,
@@ -201,11 +220,22 @@ class IncidentTeamsApi:
         :type include: IncidentRelatedObject, optional
         :rtype: IncidentTeamResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["team_id"] = team_id
+
+        if include is not unset:
+            kwargs["include"] = include
 
         return self._get_incident_team_endpoint.call_with_http_info(**kwargs)
 
-    def list_incident_teams(self, **kwargs):
+    def list_incident_teams(
+        self,
+        *,
+        include: Union[IncidentRelatedObject, UnsetType] = unset,
+        page_size: Union[int, UnsetType] = unset,
+        page_offset: Union[int, UnsetType] = unset,
+        filter: Union[str, UnsetType] = unset,
+    ) -> IncidentTeamsResponse:
         """Get a list of all incident teams.
 
         Get all incident teams for the requesting user's organization. If the ``include[users]`` query parameter is provided, the included attribute will contain the users related to these incident teams.
@@ -220,9 +250,26 @@ class IncidentTeamsApi:
         :type filter: str, optional
         :rtype: IncidentTeamsResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if include is not unset:
+            kwargs["include"] = include
+
+        if page_size is not unset:
+            kwargs["page_size"] = page_size
+
+        if page_offset is not unset:
+            kwargs["page_offset"] = page_offset
+
+        if filter is not unset:
+            kwargs["filter"] = filter
+
         return self._list_incident_teams_endpoint.call_with_http_info(**kwargs)
 
-    def update_incident_team(self, team_id, body, **kwargs):
+    def update_incident_team(
+        self,
+        team_id: str,
+        body: IncidentTeamUpdateRequest,
+    ) -> IncidentTeamResponse:
         """Update an existing incident team.
 
         Updates an existing incident team. Only provide the attributes which should be updated as this request is a partial update.
@@ -233,6 +280,7 @@ class IncidentTeamsApi:
         :type body: IncidentTeamUpdateRequest
         :rtype: IncidentTeamResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["team_id"] = team_id
 
         kwargs["body"] = body

--- a/src/datadog_api_client/v2/api/incidents_api.py
+++ b/src/datadog_api_client/v2/api/incidents_api.py
@@ -1,12 +1,16 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, List, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.model_utils import (
     set_attribute_from_path,
     get_attribute_from_path,
+    UnsetType,
+    unset,
 )
 from datadog_api_client.v2.model.incidents_response import IncidentsResponse
 from datadog_api_client.v2.model.incident_related_object import IncidentRelatedObject
@@ -170,7 +174,10 @@ class IncidentsApi:
             api_client=api_client,
         )
 
-    def create_incident(self, body, **kwargs):
+    def create_incident(
+        self,
+        body: IncidentCreateRequest,
+    ) -> IncidentResponse:
         """Create an incident.
 
         Create an incident.
@@ -179,11 +186,15 @@ class IncidentsApi:
         :type body: IncidentCreateRequest
         :rtype: IncidentResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_incident_endpoint.call_with_http_info(**kwargs)
 
-    def delete_incident(self, incident_id, **kwargs):
+    def delete_incident(
+        self,
+        incident_id: str,
+    ) -> None:
         """Delete an existing incident.
 
         Deletes an existing incident from the users organization.
@@ -192,11 +203,17 @@ class IncidentsApi:
         :type incident_id: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["incident_id"] = incident_id
 
         return self._delete_incident_endpoint.call_with_http_info(**kwargs)
 
-    def get_incident(self, incident_id, **kwargs):
+    def get_incident(
+        self,
+        incident_id: str,
+        *,
+        include: Union[List[IncidentRelatedObject], UnsetType] = unset,
+    ) -> IncidentResponse:
         """Get the details of an incident.
 
         Get the details of an incident by ``incident_id``.
@@ -207,11 +224,21 @@ class IncidentsApi:
         :type include: [IncidentRelatedObject], optional
         :rtype: IncidentResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["incident_id"] = incident_id
+
+        if include is not unset:
+            kwargs["include"] = include
 
         return self._get_incident_endpoint.call_with_http_info(**kwargs)
 
-    def list_incidents(self, **kwargs):
+    def list_incidents(
+        self,
+        *,
+        include: Union[List[IncidentRelatedObject], UnsetType] = unset,
+        page_size: Union[int, UnsetType] = unset,
+        page_offset: Union[int, UnsetType] = unset,
+    ) -> IncidentsResponse:
         """Get a list of incidents.
 
         Get all incidents for the user's organization.
@@ -224,6 +251,16 @@ class IncidentsApi:
         :type page_offset: int, optional
         :rtype: IncidentsResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if include is not unset:
+            kwargs["include"] = include
+
+        if page_size is not unset:
+            kwargs["page_size"] = page_size
+
+        if page_offset is not unset:
+            kwargs["page_offset"] = page_offset
+
         return self._list_incidents_endpoint.call_with_http_info(**kwargs)
 
     def list_incidents_with_pagination(self, **kwargs):
@@ -257,7 +294,13 @@ class IncidentsApi:
                 endpoint.params_map,
             )
 
-    def update_incident(self, incident_id, body, **kwargs):
+    def update_incident(
+        self,
+        incident_id: str,
+        body: IncidentUpdateRequest,
+        *,
+        include: Union[List[IncidentRelatedObject], UnsetType] = unset,
+    ) -> IncidentResponse:
         """Update an existing incident.
 
         Updates an incident. Provide only the attributes that should be updated as this request is a partial update.
@@ -270,7 +313,11 @@ class IncidentsApi:
         :type include: [IncidentRelatedObject], optional
         :rtype: IncidentResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["incident_id"] = incident_id
+
+        if include is not unset:
+            kwargs["include"] = include
 
         kwargs["body"] = body
 

--- a/src/datadog_api_client/v2/api/key_management_api.py
+++ b/src/datadog_api_client/v2/api/key_management_api.py
@@ -1,9 +1,15 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
+from datadog_api_client.model_utils import (
+    UnsetType,
+    unset,
+)
 from datadog_api_client.v2.model.api_keys_response import APIKeysResponse
 from datadog_api_client.v2.model.api_keys_sort import APIKeysSort
 from datadog_api_client.v2.model.api_key_response import APIKeyResponse
@@ -474,7 +480,10 @@ class KeyManagementApi:
             api_client=api_client,
         )
 
-    def create_api_key(self, body, **kwargs):
+    def create_api_key(
+        self,
+        body: APIKeyCreateRequest,
+    ) -> APIKeyResponse:
         """Create an API key.
 
         Create an API key.
@@ -482,11 +491,15 @@ class KeyManagementApi:
         :type body: APIKeyCreateRequest
         :rtype: APIKeyResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_api_key_endpoint.call_with_http_info(**kwargs)
 
-    def create_current_user_application_key(self, body, **kwargs):
+    def create_current_user_application_key(
+        self,
+        body: ApplicationKeyCreateRequest,
+    ) -> ApplicationKeyResponse:
         """Create an application key for current user.
 
         Create an application key for current user
@@ -494,11 +507,15 @@ class KeyManagementApi:
         :type body: ApplicationKeyCreateRequest
         :rtype: ApplicationKeyResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_current_user_application_key_endpoint.call_with_http_info(**kwargs)
 
-    def delete_api_key(self, api_key_id, **kwargs):
+    def delete_api_key(
+        self,
+        api_key_id: str,
+    ) -> None:
         """Delete an API key.
 
         Delete an API key.
@@ -507,11 +524,15 @@ class KeyManagementApi:
         :type api_key_id: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["api_key_id"] = api_key_id
 
         return self._delete_api_key_endpoint.call_with_http_info(**kwargs)
 
-    def delete_application_key(self, app_key_id, **kwargs):
+    def delete_application_key(
+        self,
+        app_key_id: str,
+    ) -> None:
         """Delete an application key.
 
         Delete an application key
@@ -520,11 +541,15 @@ class KeyManagementApi:
         :type app_key_id: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["app_key_id"] = app_key_id
 
         return self._delete_application_key_endpoint.call_with_http_info(**kwargs)
 
-    def delete_current_user_application_key(self, app_key_id, **kwargs):
+    def delete_current_user_application_key(
+        self,
+        app_key_id: str,
+    ) -> None:
         """Delete an application key owned by current user.
 
         Delete an application key owned by current user
@@ -533,11 +558,17 @@ class KeyManagementApi:
         :type app_key_id: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["app_key_id"] = app_key_id
 
         return self._delete_current_user_application_key_endpoint.call_with_http_info(**kwargs)
 
-    def get_api_key(self, api_key_id, **kwargs):
+    def get_api_key(
+        self,
+        api_key_id: str,
+        *,
+        include: Union[str, UnsetType] = unset,
+    ) -> APIKeyResponse:
         """Get API key.
 
         Get an API key.
@@ -548,11 +579,20 @@ class KeyManagementApi:
         :type include: str, optional
         :rtype: APIKeyResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["api_key_id"] = api_key_id
+
+        if include is not unset:
+            kwargs["include"] = include
 
         return self._get_api_key_endpoint.call_with_http_info(**kwargs)
 
-    def get_application_key(self, app_key_id, **kwargs):
+    def get_application_key(
+        self,
+        app_key_id: str,
+        *,
+        include: Union[str, UnsetType] = unset,
+    ) -> ApplicationKeyResponse:
         """Get an application key.
 
         Get an application key for your org.
@@ -563,11 +603,18 @@ class KeyManagementApi:
         :type include: str, optional
         :rtype: ApplicationKeyResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["app_key_id"] = app_key_id
+
+        if include is not unset:
+            kwargs["include"] = include
 
         return self._get_application_key_endpoint.call_with_http_info(**kwargs)
 
-    def get_current_user_application_key(self, app_key_id, **kwargs):
+    def get_current_user_application_key(
+        self,
+        app_key_id: str,
+    ) -> ApplicationKeyResponse:
         """Get one application key owned by current user.
 
         Get an application key owned by current user
@@ -576,11 +623,24 @@ class KeyManagementApi:
         :type app_key_id: str
         :rtype: ApplicationKeyResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["app_key_id"] = app_key_id
 
         return self._get_current_user_application_key_endpoint.call_with_http_info(**kwargs)
 
-    def list_api_keys(self, **kwargs):
+    def list_api_keys(
+        self,
+        *,
+        page_size: Union[int, UnsetType] = unset,
+        page_number: Union[int, UnsetType] = unset,
+        sort: Union[APIKeysSort, UnsetType] = unset,
+        filter: Union[str, UnsetType] = unset,
+        filter_created_at_start: Union[str, UnsetType] = unset,
+        filter_created_at_end: Union[str, UnsetType] = unset,
+        filter_modified_at_start: Union[str, UnsetType] = unset,
+        filter_modified_at_end: Union[str, UnsetType] = unset,
+        include: Union[str, UnsetType] = unset,
+    ) -> APIKeysResponse:
         """Get all API keys.
 
         List all API keys available for your account.
@@ -607,9 +667,46 @@ class KeyManagementApi:
         :type include: str, optional
         :rtype: APIKeysResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if page_size is not unset:
+            kwargs["page_size"] = page_size
+
+        if page_number is not unset:
+            kwargs["page_number"] = page_number
+
+        if sort is not unset:
+            kwargs["sort"] = sort
+
+        if filter is not unset:
+            kwargs["filter"] = filter
+
+        if filter_created_at_start is not unset:
+            kwargs["filter_created_at_start"] = filter_created_at_start
+
+        if filter_created_at_end is not unset:
+            kwargs["filter_created_at_end"] = filter_created_at_end
+
+        if filter_modified_at_start is not unset:
+            kwargs["filter_modified_at_start"] = filter_modified_at_start
+
+        if filter_modified_at_end is not unset:
+            kwargs["filter_modified_at_end"] = filter_modified_at_end
+
+        if include is not unset:
+            kwargs["include"] = include
+
         return self._list_api_keys_endpoint.call_with_http_info(**kwargs)
 
-    def list_application_keys(self, **kwargs):
+    def list_application_keys(
+        self,
+        *,
+        page_size: Union[int, UnsetType] = unset,
+        page_number: Union[int, UnsetType] = unset,
+        sort: Union[ApplicationKeysSort, UnsetType] = unset,
+        filter: Union[str, UnsetType] = unset,
+        filter_created_at_start: Union[str, UnsetType] = unset,
+        filter_created_at_end: Union[str, UnsetType] = unset,
+    ) -> ListApplicationKeysResponse:
         """Get all application keys.
 
         List all application keys available for your org
@@ -630,9 +727,37 @@ class KeyManagementApi:
         :type filter_created_at_end: str, optional
         :rtype: ListApplicationKeysResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if page_size is not unset:
+            kwargs["page_size"] = page_size
+
+        if page_number is not unset:
+            kwargs["page_number"] = page_number
+
+        if sort is not unset:
+            kwargs["sort"] = sort
+
+        if filter is not unset:
+            kwargs["filter"] = filter
+
+        if filter_created_at_start is not unset:
+            kwargs["filter_created_at_start"] = filter_created_at_start
+
+        if filter_created_at_end is not unset:
+            kwargs["filter_created_at_end"] = filter_created_at_end
+
         return self._list_application_keys_endpoint.call_with_http_info(**kwargs)
 
-    def list_current_user_application_keys(self, **kwargs):
+    def list_current_user_application_keys(
+        self,
+        *,
+        page_size: Union[int, UnsetType] = unset,
+        page_number: Union[int, UnsetType] = unset,
+        sort: Union[ApplicationKeysSort, UnsetType] = unset,
+        filter: Union[str, UnsetType] = unset,
+        filter_created_at_start: Union[str, UnsetType] = unset,
+        filter_created_at_end: Union[str, UnsetType] = unset,
+    ) -> ListApplicationKeysResponse:
         """Get all application keys owned by current user.
 
         List all application keys available for current user
@@ -653,9 +778,32 @@ class KeyManagementApi:
         :type filter_created_at_end: str, optional
         :rtype: ListApplicationKeysResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if page_size is not unset:
+            kwargs["page_size"] = page_size
+
+        if page_number is not unset:
+            kwargs["page_number"] = page_number
+
+        if sort is not unset:
+            kwargs["sort"] = sort
+
+        if filter is not unset:
+            kwargs["filter"] = filter
+
+        if filter_created_at_start is not unset:
+            kwargs["filter_created_at_start"] = filter_created_at_start
+
+        if filter_created_at_end is not unset:
+            kwargs["filter_created_at_end"] = filter_created_at_end
+
         return self._list_current_user_application_keys_endpoint.call_with_http_info(**kwargs)
 
-    def update_api_key(self, api_key_id, body, **kwargs):
+    def update_api_key(
+        self,
+        api_key_id: str,
+        body: APIKeyUpdateRequest,
+    ) -> APIKeyResponse:
         """Edit an API key.
 
         Update an API key.
@@ -665,13 +813,18 @@ class KeyManagementApi:
         :type body: APIKeyUpdateRequest
         :rtype: APIKeyResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["api_key_id"] = api_key_id
 
         kwargs["body"] = body
 
         return self._update_api_key_endpoint.call_with_http_info(**kwargs)
 
-    def update_application_key(self, app_key_id, body, **kwargs):
+    def update_application_key(
+        self,
+        app_key_id: str,
+        body: ApplicationKeyUpdateRequest,
+    ) -> ApplicationKeyResponse:
         """Edit an application key.
 
         Edit an application key
@@ -681,13 +834,18 @@ class KeyManagementApi:
         :type body: ApplicationKeyUpdateRequest
         :rtype: ApplicationKeyResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["app_key_id"] = app_key_id
 
         kwargs["body"] = body
 
         return self._update_application_key_endpoint.call_with_http_info(**kwargs)
 
-    def update_current_user_application_key(self, app_key_id, body, **kwargs):
+    def update_current_user_application_key(
+        self,
+        app_key_id: str,
+        body: ApplicationKeyUpdateRequest,
+    ) -> ApplicationKeyResponse:
         """Edit an application key owned by current user.
 
         Edit an application key owned by current user
@@ -697,6 +855,7 @@ class KeyManagementApi:
         :type body: ApplicationKeyUpdateRequest
         :rtype: ApplicationKeyResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["app_key_id"] = app_key_id
 
         kwargs["body"] = body

--- a/src/datadog_api_client/v2/api/logs_api.py
+++ b/src/datadog_api_client/v2/api/logs_api.py
@@ -1,13 +1,17 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.model_utils import (
     datetime,
     set_attribute_from_path,
     get_attribute_from_path,
+    UnsetType,
+    unset,
 )
 from datadog_api_client.v2.model.content_encoding import ContentEncoding
 from datadog_api_client.v2.model.http_log import HTTPLog
@@ -208,7 +212,10 @@ class LogsApi:
             api_client=api_client,
         )
 
-    def aggregate_logs(self, body, **kwargs):
+    def aggregate_logs(
+        self,
+        body: LogsAggregateRequest,
+    ) -> LogsAggregateResponse:
         """Aggregate events.
 
         The API endpoint to aggregate events into buckets and compute metrics and timeseries.
@@ -216,11 +223,16 @@ class LogsApi:
         :type body: LogsAggregateRequest
         :rtype: LogsAggregateResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._aggregate_logs_endpoint.call_with_http_info(**kwargs)
 
-    def list_logs(self, **kwargs):
+    def list_logs(
+        self,
+        *,
+        body: Union[LogsListRequest, UnsetType] = unset,
+    ) -> LogsListResponse:
         """Search logs.
 
         List endpoint returns logs that match a log search query.
@@ -235,6 +247,10 @@ class LogsApi:
         :type body: LogsListRequest, optional
         :rtype: LogsListResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if body is not unset:
+            kwargs["body"] = body
+
         return self._list_logs_endpoint.call_with_http_info(**kwargs)
 
     def list_logs_with_pagination(self, **kwargs):
@@ -260,7 +276,17 @@ class LogsApi:
                 kwargs, "body.page.cursor", get_attribute_from_path(response, "meta.page.after"), endpoint.params_map
             )
 
-    def list_logs_get(self, **kwargs):
+    def list_logs_get(
+        self,
+        *,
+        filter_query: Union[str, UnsetType] = unset,
+        filter_index: Union[str, UnsetType] = unset,
+        filter_from: Union[datetime, UnsetType] = unset,
+        filter_to: Union[datetime, UnsetType] = unset,
+        sort: Union[LogsSort, UnsetType] = unset,
+        page_cursor: Union[str, UnsetType] = unset,
+        page_limit: Union[int, UnsetType] = unset,
+    ) -> LogsListResponse:
         """Get a list of logs.
 
         List endpoint returns logs that match a log search query.
@@ -289,6 +315,28 @@ class LogsApi:
         :type page_limit: int, optional
         :rtype: LogsListResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if filter_query is not unset:
+            kwargs["filter_query"] = filter_query
+
+        if filter_index is not unset:
+            kwargs["filter_index"] = filter_index
+
+        if filter_from is not unset:
+            kwargs["filter_from"] = filter_from
+
+        if filter_to is not unset:
+            kwargs["filter_to"] = filter_to
+
+        if sort is not unset:
+            kwargs["sort"] = sort
+
+        if page_cursor is not unset:
+            kwargs["page_cursor"] = page_cursor
+
+        if page_limit is not unset:
+            kwargs["page_limit"] = page_limit
+
         return self._list_logs_get_endpoint.call_with_http_info(**kwargs)
 
     def list_logs_get_with_pagination(self, **kwargs):
@@ -328,7 +376,13 @@ class LogsApi:
                 kwargs, "page_cursor", get_attribute_from_path(response, "meta.page.after"), endpoint.params_map
             )
 
-    def submit_log(self, body, **kwargs):
+    def submit_log(
+        self,
+        body: HTTPLog,
+        *,
+        content_encoding: Union[ContentEncoding, UnsetType] = unset,
+        ddtags: Union[str, UnsetType] = unset,
+    ) -> dict:
         """Send logs.
 
         Send your logs to your Datadog platform over HTTP. Limits per HTTP request are:
@@ -368,6 +422,13 @@ class LogsApi:
         :type ddtags: str, optional
         :rtype: dict
         """
+        kwargs: Dict[str, Any] = {}
+        if content_encoding is not unset:
+            kwargs["content_encoding"] = content_encoding
+
+        if ddtags is not unset:
+            kwargs["ddtags"] = ddtags
+
         kwargs["body"] = body
 
         return self._submit_log_endpoint.call_with_http_info(**kwargs)

--- a/src/datadog_api_client/v2/api/logs_archives_api.py
+++ b/src/datadog_api_client/v2/api/logs_archives_api.py
@@ -1,7 +1,9 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.v2.model.logs_archive_order import LogsArchiveOrder
@@ -259,7 +261,11 @@ class LogsArchivesApi:
             api_client=api_client,
         )
 
-    def add_read_role_to_archive(self, archive_id, body, **kwargs):
+    def add_read_role_to_archive(
+        self,
+        archive_id: str,
+        body: RelationshipToRole,
+    ) -> None:
         """Grant role to an archive.
 
         Adds a read role to an archive. ( `Roles API <https://docs.datadoghq.com/api/v2/roles/>`_ )
@@ -269,13 +275,17 @@ class LogsArchivesApi:
         :type body: RelationshipToRole
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["archive_id"] = archive_id
 
         kwargs["body"] = body
 
         return self._add_read_role_to_archive_endpoint.call_with_http_info(**kwargs)
 
-    def create_logs_archive(self, body, **kwargs):
+    def create_logs_archive(
+        self,
+        body: LogsArchiveCreateRequest,
+    ) -> LogsArchive:
         """Create an archive.
 
         Create an archive in your organization.
@@ -284,11 +294,15 @@ class LogsArchivesApi:
         :type body: LogsArchiveCreateRequest
         :rtype: LogsArchive
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_logs_archive_endpoint.call_with_http_info(**kwargs)
 
-    def delete_logs_archive(self, archive_id, **kwargs):
+    def delete_logs_archive(
+        self,
+        archive_id: str,
+    ) -> None:
         """Delete an archive.
 
         Delete a given archive from your organization.
@@ -297,11 +311,15 @@ class LogsArchivesApi:
         :type archive_id: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["archive_id"] = archive_id
 
         return self._delete_logs_archive_endpoint.call_with_http_info(**kwargs)
 
-    def get_logs_archive(self, archive_id, **kwargs):
+    def get_logs_archive(
+        self,
+        archive_id: str,
+    ) -> LogsArchive:
         """Get an archive.
 
         Get a specific archive from your organization.
@@ -310,11 +328,14 @@ class LogsArchivesApi:
         :type archive_id: str
         :rtype: LogsArchive
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["archive_id"] = archive_id
 
         return self._get_logs_archive_endpoint.call_with_http_info(**kwargs)
 
-    def get_logs_archive_order(self, **kwargs):
+    def get_logs_archive_order(
+        self,
+    ) -> LogsArchiveOrder:
         """Get archive order.
 
         Get the current order of your archives.
@@ -322,9 +343,13 @@ class LogsArchivesApi:
 
         :rtype: LogsArchiveOrder
         """
+        kwargs: Dict[str, Any] = {}
         return self._get_logs_archive_order_endpoint.call_with_http_info(**kwargs)
 
-    def list_archive_read_roles(self, archive_id, **kwargs):
+    def list_archive_read_roles(
+        self,
+        archive_id: str,
+    ) -> RolesResponse:
         """List read roles for an archive.
 
         Returns all read roles a given archive is restricted to.
@@ -333,20 +358,28 @@ class LogsArchivesApi:
         :type archive_id: str
         :rtype: RolesResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["archive_id"] = archive_id
 
         return self._list_archive_read_roles_endpoint.call_with_http_info(**kwargs)
 
-    def list_logs_archives(self, **kwargs):
+    def list_logs_archives(
+        self,
+    ) -> LogsArchives:
         """Get all archives.
 
         Get the list of configured logs archives with their definitions.
 
         :rtype: LogsArchives
         """
+        kwargs: Dict[str, Any] = {}
         return self._list_logs_archives_endpoint.call_with_http_info(**kwargs)
 
-    def remove_role_from_archive(self, archive_id, body, **kwargs):
+    def remove_role_from_archive(
+        self,
+        archive_id: str,
+        body: RelationshipToRole,
+    ) -> None:
         """Revoke role from an archive.
 
         Removes a role from an archive. ( `Roles API <https://docs.datadoghq.com/api/v2/roles/>`_ )
@@ -356,13 +389,18 @@ class LogsArchivesApi:
         :type body: RelationshipToRole
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["archive_id"] = archive_id
 
         kwargs["body"] = body
 
         return self._remove_role_from_archive_endpoint.call_with_http_info(**kwargs)
 
-    def update_logs_archive(self, archive_id, body, **kwargs):
+    def update_logs_archive(
+        self,
+        archive_id: str,
+        body: LogsArchiveCreateRequest,
+    ) -> LogsArchive:
         """Update an archive.
 
         Update a given archive configuration.
@@ -376,13 +414,17 @@ class LogsArchivesApi:
         :type body: LogsArchiveCreateRequest
         :rtype: LogsArchive
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["archive_id"] = archive_id
 
         kwargs["body"] = body
 
         return self._update_logs_archive_endpoint.call_with_http_info(**kwargs)
 
-    def update_logs_archive_order(self, body, **kwargs):
+    def update_logs_archive_order(
+        self,
+        body: LogsArchiveOrder,
+    ) -> LogsArchiveOrder:
         """Update archive order.
 
         Update the order of your archives. Since logs are processed sequentially, reordering an archive may change
@@ -395,6 +437,7 @@ class LogsArchivesApi:
         :type body: LogsArchiveOrder
         :rtype: LogsArchiveOrder
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._update_logs_archive_order_endpoint.call_with_http_info(**kwargs)

--- a/src/datadog_api_client/v2/api/logs_metrics_api.py
+++ b/src/datadog_api_client/v2/api/logs_metrics_api.py
@@ -1,7 +1,9 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.v2.model.logs_metrics_response import LogsMetricsResponse
@@ -136,7 +138,10 @@ class LogsMetricsApi:
             api_client=api_client,
         )
 
-    def create_logs_metric(self, body, **kwargs):
+    def create_logs_metric(
+        self,
+        body: LogsMetricCreateRequest,
+    ) -> LogsMetricResponse:
         """Create a log-based metric.
 
         Create a metric based on your ingested logs in your organization.
@@ -146,11 +151,15 @@ class LogsMetricsApi:
         :type body: LogsMetricCreateRequest
         :rtype: LogsMetricResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_logs_metric_endpoint.call_with_http_info(**kwargs)
 
-    def delete_logs_metric(self, metric_id, **kwargs):
+    def delete_logs_metric(
+        self,
+        metric_id: str,
+    ) -> None:
         """Delete a log-based metric.
 
         Delete a specific log-based metric from your organization.
@@ -159,11 +168,15 @@ class LogsMetricsApi:
         :type metric_id: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["metric_id"] = metric_id
 
         return self._delete_logs_metric_endpoint.call_with_http_info(**kwargs)
 
-    def get_logs_metric(self, metric_id, **kwargs):
+    def get_logs_metric(
+        self,
+        metric_id: str,
+    ) -> LogsMetricResponse:
         """Get a log-based metric.
 
         Get a specific log-based metric from your organization.
@@ -172,20 +185,28 @@ class LogsMetricsApi:
         :type metric_id: str
         :rtype: LogsMetricResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["metric_id"] = metric_id
 
         return self._get_logs_metric_endpoint.call_with_http_info(**kwargs)
 
-    def list_logs_metrics(self, **kwargs):
+    def list_logs_metrics(
+        self,
+    ) -> LogsMetricsResponse:
         """Get all log-based metrics.
 
         Get the list of configured log-based metrics with their definitions.
 
         :rtype: LogsMetricsResponse
         """
+        kwargs: Dict[str, Any] = {}
         return self._list_logs_metrics_endpoint.call_with_http_info(**kwargs)
 
-    def update_logs_metric(self, metric_id, body, **kwargs):
+    def update_logs_metric(
+        self,
+        metric_id: str,
+        body: LogsMetricUpdateRequest,
+    ) -> LogsMetricResponse:
         """Update a log-based metric.
 
         Update a specific log-based metric from your organization.
@@ -197,6 +218,7 @@ class LogsMetricsApi:
         :type body: LogsMetricUpdateRequest
         :rtype: LogsMetricResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["metric_id"] = metric_id
 
         kwargs["body"] = body

--- a/src/datadog_api_client/v2/api/metrics_api.py
+++ b/src/datadog_api_client/v2/api/metrics_api.py
@@ -1,9 +1,15 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
+from datadog_api_client.model_utils import (
+    UnsetType,
+    unset,
+)
 from datadog_api_client.v2.model.metrics_and_metric_tag_configurations_response import (
     MetricsAndMetricTagConfigurationsResponse,
 )
@@ -366,7 +372,10 @@ class MetricsApi:
             api_client=api_client,
         )
 
-    def create_bulk_tags_metrics_configuration(self, body, **kwargs):
+    def create_bulk_tags_metrics_configuration(
+        self,
+        body: MetricBulkTagConfigCreateRequest,
+    ) -> MetricBulkTagConfigResponse:
         """Configure tags for multiple metrics.
 
         Create and define a list of queryable tag keys for a set of existing count, gauge, rate, and distribution metrics.
@@ -379,11 +388,16 @@ class MetricsApi:
         :type body: MetricBulkTagConfigCreateRequest
         :rtype: MetricBulkTagConfigResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_bulk_tags_metrics_configuration_endpoint.call_with_http_info(**kwargs)
 
-    def create_tag_configuration(self, metric_name, body, **kwargs):
+    def create_tag_configuration(
+        self,
+        metric_name: str,
+        body: MetricTagConfigurationCreateRequest,
+    ) -> MetricTagConfigurationResponse:
         """Create a tag configuration.
 
         Create and define a list of queryable tag keys for an existing count/gauge/rate/distribution metric.
@@ -396,13 +410,17 @@ class MetricsApi:
         :type body: MetricTagConfigurationCreateRequest
         :rtype: MetricTagConfigurationResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["metric_name"] = metric_name
 
         kwargs["body"] = body
 
         return self._create_tag_configuration_endpoint.call_with_http_info(**kwargs)
 
-    def delete_bulk_tags_metrics_configuration(self, body, **kwargs):
+    def delete_bulk_tags_metrics_configuration(
+        self,
+        body: MetricBulkTagConfigDeleteRequest,
+    ) -> MetricBulkTagConfigResponse:
         """Configure tags for multiple metrics.
 
         Delete all custom lists of queryable tag keys for a set of existing count, gauge, rate, and distribution metrics.
@@ -413,11 +431,15 @@ class MetricsApi:
         :type body: MetricBulkTagConfigDeleteRequest
         :rtype: MetricBulkTagConfigResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._delete_bulk_tags_metrics_configuration_endpoint.call_with_http_info(**kwargs)
 
-    def delete_tag_configuration(self, metric_name, **kwargs):
+    def delete_tag_configuration(
+        self,
+        metric_name: str,
+    ) -> None:
         """Delete a tag configuration.
 
         Deletes a metric's tag configuration. Can only be used with application
@@ -427,11 +449,21 @@ class MetricsApi:
         :type metric_name: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["metric_name"] = metric_name
 
         return self._delete_tag_configuration_endpoint.call_with_http_info(**kwargs)
 
-    def estimate_metrics_output_series(self, metric_name, **kwargs):
+    def estimate_metrics_output_series(
+        self,
+        metric_name: str,
+        *,
+        filter_groups: Union[str, UnsetType] = unset,
+        filter_hours_ago: Union[int, UnsetType] = unset,
+        filter_num_aggregations: Union[int, UnsetType] = unset,
+        filter_pct: Union[bool, UnsetType] = unset,
+        filter_timespan_h: Union[int, UnsetType] = unset,
+    ) -> MetricEstimateResponse:
         """Tag Configuration Cardinality Estimator.
 
         Returns the estimated cardinality for a metric with a given tag, percentile and number of aggregations configuration using Metrics without Limits&trade;.
@@ -450,11 +482,30 @@ class MetricsApi:
         :type filter_timespan_h: int, optional
         :rtype: MetricEstimateResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["metric_name"] = metric_name
+
+        if filter_groups is not unset:
+            kwargs["filter_groups"] = filter_groups
+
+        if filter_hours_ago is not unset:
+            kwargs["filter_hours_ago"] = filter_hours_ago
+
+        if filter_num_aggregations is not unset:
+            kwargs["filter_num_aggregations"] = filter_num_aggregations
+
+        if filter_pct is not unset:
+            kwargs["filter_pct"] = filter_pct
+
+        if filter_timespan_h is not unset:
+            kwargs["filter_timespan_h"] = filter_timespan_h
 
         return self._estimate_metrics_output_series_endpoint.call_with_http_info(**kwargs)
 
-    def list_tag_configuration_by_name(self, metric_name, **kwargs):
+    def list_tag_configuration_by_name(
+        self,
+        metric_name: str,
+    ) -> MetricTagConfigurationResponse:
         """List tag configuration by name.
 
         Returns the tag configuration for the given metric name.
@@ -463,11 +514,21 @@ class MetricsApi:
         :type metric_name: str
         :rtype: MetricTagConfigurationResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["metric_name"] = metric_name
 
         return self._list_tag_configuration_by_name_endpoint.call_with_http_info(**kwargs)
 
-    def list_tag_configurations(self, **kwargs):
+    def list_tag_configurations(
+        self,
+        *,
+        filter_configured: Union[bool, UnsetType] = unset,
+        filter_tags_configured: Union[str, UnsetType] = unset,
+        filter_metric_type: Union[MetricTagConfigurationMetricTypes, UnsetType] = unset,
+        filter_include_percentiles: Union[bool, UnsetType] = unset,
+        filter_tags: Union[str, UnsetType] = unset,
+        window_seconds: Union[int, UnsetType] = unset,
+    ) -> MetricsAndMetricTagConfigurationsResponse:
         """List tag configurations.
 
         Returns all configured count/gauge/rate/distribution metric names
@@ -490,9 +551,31 @@ class MetricsApi:
         :type window_seconds: int, optional
         :rtype: MetricsAndMetricTagConfigurationsResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if filter_configured is not unset:
+            kwargs["filter_configured"] = filter_configured
+
+        if filter_tags_configured is not unset:
+            kwargs["filter_tags_configured"] = filter_tags_configured
+
+        if filter_metric_type is not unset:
+            kwargs["filter_metric_type"] = filter_metric_type
+
+        if filter_include_percentiles is not unset:
+            kwargs["filter_include_percentiles"] = filter_include_percentiles
+
+        if filter_tags is not unset:
+            kwargs["filter_tags"] = filter_tags
+
+        if window_seconds is not unset:
+            kwargs["window_seconds"] = window_seconds
+
         return self._list_tag_configurations_endpoint.call_with_http_info(**kwargs)
 
-    def list_tags_by_metric_name(self, metric_name, **kwargs):
+    def list_tags_by_metric_name(
+        self,
+        metric_name: str,
+    ) -> MetricAllTagsResponse:
         """List tags by metric name.
 
         View indexed tag key-value pairs for a given metric name.
@@ -501,11 +584,15 @@ class MetricsApi:
         :type metric_name: str
         :rtype: MetricAllTagsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["metric_name"] = metric_name
 
         return self._list_tags_by_metric_name_endpoint.call_with_http_info(**kwargs)
 
-    def list_volumes_by_metric_name(self, metric_name, **kwargs):
+    def list_volumes_by_metric_name(
+        self,
+        metric_name: str,
+    ) -> MetricVolumesResponse:
         """List distinct metric volumes by metric name.
 
         View distinct metrics volumes for the given metric name.
@@ -516,11 +603,17 @@ class MetricsApi:
         :type metric_name: str
         :rtype: MetricVolumesResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["metric_name"] = metric_name
 
         return self._list_volumes_by_metric_name_endpoint.call_with_http_info(**kwargs)
 
-    def submit_metrics(self, body, **kwargs):
+    def submit_metrics(
+        self,
+        body: MetricPayload,
+        *,
+        content_encoding: Union[MetricContentEncoding, UnsetType] = unset,
+    ) -> IntakePayloadAccepted:
         """Submit metrics.
 
         The metrics end-point allows you to post time-series data that can be graphed on Datadog’s dashboards.
@@ -540,11 +633,19 @@ class MetricsApi:
         :type content_encoding: MetricContentEncoding, optional
         :rtype: IntakePayloadAccepted
         """
+        kwargs: Dict[str, Any] = {}
+        if content_encoding is not unset:
+            kwargs["content_encoding"] = content_encoding
+
         kwargs["body"] = body
 
         return self._submit_metrics_endpoint.call_with_http_info(**kwargs)
 
-    def update_tag_configuration(self, metric_name, body, **kwargs):
+    def update_tag_configuration(
+        self,
+        metric_name: str,
+        body: MetricTagConfigurationUpdateRequest,
+    ) -> MetricTagConfigurationResponse:
         """Update a tag configuration.
 
         Update the tag configuration of a metric or percentile aggregations of a distribution metric or custom aggregations
@@ -556,6 +657,7 @@ class MetricsApi:
         :type body: MetricTagConfigurationUpdateRequest
         :rtype: MetricTagConfigurationResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["metric_name"] = metric_name
 
         kwargs["body"] = body

--- a/src/datadog_api_client/v2/api/opsgenie_integration_api.py
+++ b/src/datadog_api_client/v2/api/opsgenie_integration_api.py
@@ -1,7 +1,9 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.v2.model.opsgenie_services_response import OpsgenieServicesResponse
@@ -137,7 +139,10 @@ class OpsgenieIntegrationApi:
             api_client=api_client,
         )
 
-    def create_opsgenie_service(self, body, **kwargs):
+    def create_opsgenie_service(
+        self,
+        body: OpsgenieServiceCreateRequest,
+    ) -> OpsgenieServiceResponse:
         """Create a new service object.
 
         Create a new service object in the Opsgenie integration.
@@ -146,11 +151,15 @@ class OpsgenieIntegrationApi:
         :type body: OpsgenieServiceCreateRequest
         :rtype: OpsgenieServiceResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_opsgenie_service_endpoint.call_with_http_info(**kwargs)
 
-    def delete_opsgenie_service(self, integration_service_id, **kwargs):
+    def delete_opsgenie_service(
+        self,
+        integration_service_id: str,
+    ) -> None:
         """Delete a single service object.
 
         Delete a single service object in the Datadog Opsgenie integration.
@@ -159,11 +168,15 @@ class OpsgenieIntegrationApi:
         :type integration_service_id: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["integration_service_id"] = integration_service_id
 
         return self._delete_opsgenie_service_endpoint.call_with_http_info(**kwargs)
 
-    def get_opsgenie_service(self, integration_service_id, **kwargs):
+    def get_opsgenie_service(
+        self,
+        integration_service_id: str,
+    ) -> OpsgenieServiceResponse:
         """Get a single service object.
 
         Get a single service from the Datadog Opsgenie integration.
@@ -172,20 +185,28 @@ class OpsgenieIntegrationApi:
         :type integration_service_id: str
         :rtype: OpsgenieServiceResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["integration_service_id"] = integration_service_id
 
         return self._get_opsgenie_service_endpoint.call_with_http_info(**kwargs)
 
-    def list_opsgenie_services(self, **kwargs):
+    def list_opsgenie_services(
+        self,
+    ) -> OpsgenieServicesResponse:
         """Get all service objects.
 
         Get a list of all services from the Datadog Opsgenie integration.
 
         :rtype: OpsgenieServicesResponse
         """
+        kwargs: Dict[str, Any] = {}
         return self._list_opsgenie_services_endpoint.call_with_http_info(**kwargs)
 
-    def update_opsgenie_service(self, integration_service_id, body, **kwargs):
+    def update_opsgenie_service(
+        self,
+        integration_service_id: str,
+        body: OpsgenieServiceUpdateRequest,
+    ) -> OpsgenieServiceResponse:
         """Update a single service object.
 
         Update a single service object in the Datadog Opsgenie integration.
@@ -196,6 +217,7 @@ class OpsgenieIntegrationApi:
         :type body: OpsgenieServiceUpdateRequest
         :rtype: OpsgenieServiceResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["integration_service_id"] = integration_service_id
 
         kwargs["body"] = body

--- a/src/datadog_api_client/v2/api/organizations_api.py
+++ b/src/datadog_api_client/v2/api/organizations_api.py
@@ -1,11 +1,15 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.model_utils import (
     file_type,
+    UnsetType,
+    unset,
 )
 
 
@@ -40,7 +44,11 @@ class OrganizationsApi:
             api_client=api_client,
         )
 
-    def upload_idp_metadata(self, **kwargs):
+    def upload_idp_metadata(
+        self,
+        *,
+        idp_file: Union[file_type, UnsetType] = unset,
+    ) -> None:
         """Upload IdP metadata.
 
         Endpoint for uploading IdP metadata for SAML setup.
@@ -51,4 +59,8 @@ class OrganizationsApi:
         :type idp_file: file_type, optional
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
+        if idp_file is not unset:
+            kwargs["idp_file"] = idp_file
+
         return self._upload_idp_metadata_endpoint.call_with_http_info(**kwargs)

--- a/src/datadog_api_client/v2/api/processes_api.py
+++ b/src/datadog_api_client/v2/api/processes_api.py
@@ -1,12 +1,16 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.model_utils import (
     set_attribute_from_path,
     get_attribute_from_path,
+    UnsetType,
+    unset,
 )
 from datadog_api_client.v2.model.process_summaries_response import ProcessSummariesResponse
 
@@ -74,7 +78,16 @@ class ProcessesApi:
             api_client=api_client,
         )
 
-    def list_processes(self, **kwargs):
+    def list_processes(
+        self,
+        *,
+        search: Union[str, UnsetType] = unset,
+        tags: Union[str, UnsetType] = unset,
+        _from: Union[int, UnsetType] = unset,
+        to: Union[int, UnsetType] = unset,
+        page_limit: Union[int, UnsetType] = unset,
+        page_cursor: Union[str, UnsetType] = unset,
+    ) -> ProcessSummariesResponse:
         """Get all processes.
 
         Get all processes for your organization.
@@ -98,6 +111,25 @@ class ProcessesApi:
         :type page_cursor: str, optional
         :rtype: ProcessSummariesResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if search is not unset:
+            kwargs["search"] = search
+
+        if tags is not unset:
+            kwargs["tags"] = tags
+
+        if _from is not unset:
+            kwargs["_from"] = _from
+
+        if to is not unset:
+            kwargs["to"] = to
+
+        if page_limit is not unset:
+            kwargs["page_limit"] = page_limit
+
+        if page_cursor is not unset:
+            kwargs["page_cursor"] = page_cursor
+
         return self._list_processes_endpoint.call_with_http_info(**kwargs)
 
     def list_processes_with_pagination(self, **kwargs):

--- a/src/datadog_api_client/v2/api/roles_api.py
+++ b/src/datadog_api_client/v2/api/roles_api.py
@@ -1,9 +1,15 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
+from datadog_api_client.model_utils import (
+    UnsetType,
+    unset,
+)
 from datadog_api_client.v2.model.permissions_response import PermissionsResponse
 from datadog_api_client.v2.model.roles_response import RolesResponse
 from datadog_api_client.v2.model.roles_sort import RolesSort
@@ -395,7 +401,11 @@ class RolesApi:
             api_client=api_client,
         )
 
-    def add_permission_to_role(self, role_id, body, **kwargs):
+    def add_permission_to_role(
+        self,
+        role_id: str,
+        body: RelationshipToPermission,
+    ) -> PermissionsResponse:
         """Grant permission to a role.
 
         Adds a permission to a role.
@@ -405,13 +415,18 @@ class RolesApi:
         :type body: RelationshipToPermission
         :rtype: PermissionsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["role_id"] = role_id
 
         kwargs["body"] = body
 
         return self._add_permission_to_role_endpoint.call_with_http_info(**kwargs)
 
-    def add_user_to_role(self, role_id, body, **kwargs):
+    def add_user_to_role(
+        self,
+        role_id: str,
+        body: RelationshipToUser,
+    ) -> UsersResponse:
         """Add a user to a role.
 
         Adds a user to a role.
@@ -421,13 +436,18 @@ class RolesApi:
         :type body: RelationshipToUser
         :rtype: UsersResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["role_id"] = role_id
 
         kwargs["body"] = body
 
         return self._add_user_to_role_endpoint.call_with_http_info(**kwargs)
 
-    def clone_role(self, role_id, body, **kwargs):
+    def clone_role(
+        self,
+        role_id: str,
+        body: RoleCloneRequest,
+    ) -> RoleResponse:
         """Create a new role by cloning an existing role.
 
         Clone an existing role
@@ -437,13 +457,17 @@ class RolesApi:
         :type body: RoleCloneRequest
         :rtype: RoleResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["role_id"] = role_id
 
         kwargs["body"] = body
 
         return self._clone_role_endpoint.call_with_http_info(**kwargs)
 
-    def create_role(self, body, **kwargs):
+    def create_role(
+        self,
+        body: RoleCreateRequest,
+    ) -> RoleCreateResponse:
         """Create role.
 
         Create a new role for your organization.
@@ -451,11 +475,15 @@ class RolesApi:
         :type body: RoleCreateRequest
         :rtype: RoleCreateResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_role_endpoint.call_with_http_info(**kwargs)
 
-    def delete_role(self, role_id, **kwargs):
+    def delete_role(
+        self,
+        role_id: str,
+    ) -> None:
         """Delete role.
 
         Disables a role.
@@ -464,11 +492,15 @@ class RolesApi:
         :type role_id: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["role_id"] = role_id
 
         return self._delete_role_endpoint.call_with_http_info(**kwargs)
 
-    def get_role(self, role_id, **kwargs):
+    def get_role(
+        self,
+        role_id: str,
+    ) -> RoleResponse:
         """Get a role.
 
         Get a role in the organization specified by the role’s ``role_id``.
@@ -477,20 +509,27 @@ class RolesApi:
         :type role_id: str
         :rtype: RoleResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["role_id"] = role_id
 
         return self._get_role_endpoint.call_with_http_info(**kwargs)
 
-    def list_permissions(self, **kwargs):
+    def list_permissions(
+        self,
+    ) -> PermissionsResponse:
         """List permissions.
 
         Returns a list of all permissions, including name, description, and ID.
 
         :rtype: PermissionsResponse
         """
+        kwargs: Dict[str, Any] = {}
         return self._list_permissions_endpoint.call_with_http_info(**kwargs)
 
-    def list_role_permissions(self, role_id, **kwargs):
+    def list_role_permissions(
+        self,
+        role_id: str,
+    ) -> PermissionsResponse:
         """List permissions for a role.
 
         Returns a list of all permissions for a single role.
@@ -499,11 +538,19 @@ class RolesApi:
         :type role_id: str
         :rtype: PermissionsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["role_id"] = role_id
 
         return self._list_role_permissions_endpoint.call_with_http_info(**kwargs)
 
-    def list_roles(self, **kwargs):
+    def list_roles(
+        self,
+        *,
+        page_size: Union[int, UnsetType] = unset,
+        page_number: Union[int, UnsetType] = unset,
+        sort: Union[RolesSort, UnsetType] = unset,
+        filter: Union[str, UnsetType] = unset,
+    ) -> RolesResponse:
         """List roles.
 
         Returns all roles, including their names and their unique identifiers.
@@ -520,9 +567,30 @@ class RolesApi:
         :type filter: str, optional
         :rtype: RolesResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if page_size is not unset:
+            kwargs["page_size"] = page_size
+
+        if page_number is not unset:
+            kwargs["page_number"] = page_number
+
+        if sort is not unset:
+            kwargs["sort"] = sort
+
+        if filter is not unset:
+            kwargs["filter"] = filter
+
         return self._list_roles_endpoint.call_with_http_info(**kwargs)
 
-    def list_role_users(self, role_id, **kwargs):
+    def list_role_users(
+        self,
+        role_id: str,
+        *,
+        page_size: Union[int, UnsetType] = unset,
+        page_number: Union[int, UnsetType] = unset,
+        sort: Union[str, UnsetType] = unset,
+        filter: Union[str, UnsetType] = unset,
+    ) -> UsersResponse:
         """Get all users of a role.
 
         Gets all users of a role.
@@ -541,11 +609,28 @@ class RolesApi:
         :type filter: str, optional
         :rtype: UsersResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["role_id"] = role_id
+
+        if page_size is not unset:
+            kwargs["page_size"] = page_size
+
+        if page_number is not unset:
+            kwargs["page_number"] = page_number
+
+        if sort is not unset:
+            kwargs["sort"] = sort
+
+        if filter is not unset:
+            kwargs["filter"] = filter
 
         return self._list_role_users_endpoint.call_with_http_info(**kwargs)
 
-    def remove_permission_from_role(self, role_id, body, **kwargs):
+    def remove_permission_from_role(
+        self,
+        role_id: str,
+        body: RelationshipToPermission,
+    ) -> PermissionsResponse:
         """Revoke permission.
 
         Removes a permission from a role.
@@ -555,13 +640,18 @@ class RolesApi:
         :type body: RelationshipToPermission
         :rtype: PermissionsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["role_id"] = role_id
 
         kwargs["body"] = body
 
         return self._remove_permission_from_role_endpoint.call_with_http_info(**kwargs)
 
-    def remove_user_from_role(self, role_id, body, **kwargs):
+    def remove_user_from_role(
+        self,
+        role_id: str,
+        body: RelationshipToUser,
+    ) -> UsersResponse:
         """Remove a user from a role.
 
         Removes a user from a role.
@@ -571,13 +661,18 @@ class RolesApi:
         :type body: RelationshipToUser
         :rtype: UsersResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["role_id"] = role_id
 
         kwargs["body"] = body
 
         return self._remove_user_from_role_endpoint.call_with_http_info(**kwargs)
 
-    def update_role(self, role_id, body, **kwargs):
+    def update_role(
+        self,
+        role_id: str,
+        body: RoleUpdateRequest,
+    ) -> RoleUpdateResponse:
         """Update a role.
 
         Edit a role. Can only be used with application keys belonging to administrators.
@@ -587,6 +682,7 @@ class RolesApi:
         :type body: RoleUpdateRequest
         :rtype: RoleUpdateResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["role_id"] = role_id
 
         kwargs["body"] = body

--- a/src/datadog_api_client/v2/api/rum_api.py
+++ b/src/datadog_api_client/v2/api/rum_api.py
@@ -1,13 +1,17 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.model_utils import (
     datetime,
     set_attribute_from_path,
     get_attribute_from_path,
+    UnsetType,
+    unset,
 )
 from datadog_api_client.v2.model.rum_analytics_aggregate_response import RUMAnalyticsAggregateResponse
 from datadog_api_client.v2.model.rum_aggregate_request import RUMAggregateRequest
@@ -120,7 +124,10 @@ class RUMApi:
             api_client=api_client,
         )
 
-    def aggregate_rum_events(self, body, **kwargs):
+    def aggregate_rum_events(
+        self,
+        body: RUMAggregateRequest,
+    ) -> RUMAnalyticsAggregateResponse:
         """Aggregate RUM events.
 
         The API endpoint to aggregate RUM events into buckets of computed metrics and timeseries.
@@ -128,11 +135,21 @@ class RUMApi:
         :type body: RUMAggregateRequest
         :rtype: RUMAnalyticsAggregateResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._aggregate_rum_events_endpoint.call_with_http_info(**kwargs)
 
-    def list_rum_events(self, **kwargs):
+    def list_rum_events(
+        self,
+        *,
+        filter_query: Union[str, UnsetType] = unset,
+        filter_from: Union[datetime, UnsetType] = unset,
+        filter_to: Union[datetime, UnsetType] = unset,
+        sort: Union[RUMSort, UnsetType] = unset,
+        page_cursor: Union[str, UnsetType] = unset,
+        page_limit: Union[int, UnsetType] = unset,
+    ) -> RUMEventsResponse:
         """Get a list of RUM events.
 
         List endpoint returns events that match a RUM search query.
@@ -154,6 +171,25 @@ class RUMApi:
         :type page_limit: int, optional
         :rtype: RUMEventsResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if filter_query is not unset:
+            kwargs["filter_query"] = filter_query
+
+        if filter_from is not unset:
+            kwargs["filter_from"] = filter_from
+
+        if filter_to is not unset:
+            kwargs["filter_to"] = filter_to
+
+        if sort is not unset:
+            kwargs["sort"] = sort
+
+        if page_cursor is not unset:
+            kwargs["page_cursor"] = page_cursor
+
+        if page_limit is not unset:
+            kwargs["page_limit"] = page_limit
+
         return self._list_rum_events_endpoint.call_with_http_info(**kwargs)
 
     def list_rum_events_with_pagination(self, **kwargs):
@@ -190,7 +226,10 @@ class RUMApi:
                 kwargs, "page_cursor", get_attribute_from_path(response, "meta.page.after"), endpoint.params_map
             )
 
-    def search_rum_events(self, body, **kwargs):
+    def search_rum_events(
+        self,
+        body: RUMSearchEventsRequest,
+    ) -> RUMEventsResponse:
         """Search RUM events.
 
         List endpoint returns RUM events that match a RUM search query.
@@ -201,6 +240,7 @@ class RUMApi:
         :type body: RUMSearchEventsRequest
         :rtype: RUMEventsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._search_rum_events_endpoint.call_with_http_info(**kwargs)

--- a/src/datadog_api_client/v2/api/security_monitoring_api.py
+++ b/src/datadog_api_client/v2/api/security_monitoring_api.py
@@ -1,13 +1,17 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.model_utils import (
     datetime,
     set_attribute_from_path,
     get_attribute_from_path,
+    UnsetType,
+    unset,
 )
 from datadog_api_client.v2.model.security_filters_response import SecurityFiltersResponse
 from datadog_api_client.v2.model.security_filter_response import SecurityFilterResponse
@@ -348,7 +352,10 @@ class SecurityMonitoringApi:
             api_client=api_client,
         )
 
-    def create_security_filter(self, body, **kwargs):
+    def create_security_filter(
+        self,
+        body: SecurityFilterCreateRequest,
+    ) -> SecurityFilterResponse:
         """Create a security filter.
 
         Create a security filter.
@@ -360,11 +367,15 @@ class SecurityMonitoringApi:
         :type body: SecurityFilterCreateRequest
         :rtype: SecurityFilterResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_security_filter_endpoint.call_with_http_info(**kwargs)
 
-    def create_security_monitoring_rule(self, body, **kwargs):
+    def create_security_monitoring_rule(
+        self,
+        body: SecurityMonitoringRuleCreatePayload,
+    ) -> SecurityMonitoringRuleResponse:
         """Create a detection rule.
 
         Create a detection rule.
@@ -372,11 +383,15 @@ class SecurityMonitoringApi:
         :type body: SecurityMonitoringRuleCreatePayload
         :rtype: SecurityMonitoringRuleResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_security_monitoring_rule_endpoint.call_with_http_info(**kwargs)
 
-    def delete_security_filter(self, security_filter_id, **kwargs):
+    def delete_security_filter(
+        self,
+        security_filter_id: str,
+    ) -> None:
         """Delete a security filter.
 
         Delete a specific security filter.
@@ -385,11 +400,15 @@ class SecurityMonitoringApi:
         :type security_filter_id: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["security_filter_id"] = security_filter_id
 
         return self._delete_security_filter_endpoint.call_with_http_info(**kwargs)
 
-    def delete_security_monitoring_rule(self, rule_id, **kwargs):
+    def delete_security_monitoring_rule(
+        self,
+        rule_id: str,
+    ) -> None:
         """Delete an existing rule.
 
         Delete an existing rule. Default rules cannot be deleted.
@@ -398,11 +417,15 @@ class SecurityMonitoringApi:
         :type rule_id: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["rule_id"] = rule_id
 
         return self._delete_security_monitoring_rule_endpoint.call_with_http_info(**kwargs)
 
-    def get_security_filter(self, security_filter_id, **kwargs):
+    def get_security_filter(
+        self,
+        security_filter_id: str,
+    ) -> SecurityFilterResponse:
         """Get a security filter.
 
         Get the details of a specific security filter.
@@ -414,11 +437,15 @@ class SecurityMonitoringApi:
         :type security_filter_id: str
         :rtype: SecurityFilterResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["security_filter_id"] = security_filter_id
 
         return self._get_security_filter_endpoint.call_with_http_info(**kwargs)
 
-    def get_security_monitoring_rule(self, rule_id, **kwargs):
+    def get_security_monitoring_rule(
+        self,
+        rule_id: str,
+    ) -> SecurityMonitoringRuleResponse:
         """Get a rule's details.
 
         Get a rule's details.
@@ -427,20 +454,29 @@ class SecurityMonitoringApi:
         :type rule_id: str
         :rtype: SecurityMonitoringRuleResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["rule_id"] = rule_id
 
         return self._get_security_monitoring_rule_endpoint.call_with_http_info(**kwargs)
 
-    def list_security_filters(self, **kwargs):
+    def list_security_filters(
+        self,
+    ) -> SecurityFiltersResponse:
         """Get all security filters.
 
         Get the list of configured security filters with their definitions.
 
         :rtype: SecurityFiltersResponse
         """
+        kwargs: Dict[str, Any] = {}
         return self._list_security_filters_endpoint.call_with_http_info(**kwargs)
 
-    def list_security_monitoring_rules(self, **kwargs):
+    def list_security_monitoring_rules(
+        self,
+        *,
+        page_size: Union[int, UnsetType] = unset,
+        page_number: Union[int, UnsetType] = unset,
+    ) -> SecurityMonitoringListRulesResponse:
         """List rules.
 
         List rules.
@@ -451,9 +487,25 @@ class SecurityMonitoringApi:
         :type page_number: int, optional
         :rtype: SecurityMonitoringListRulesResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if page_size is not unset:
+            kwargs["page_size"] = page_size
+
+        if page_number is not unset:
+            kwargs["page_number"] = page_number
+
         return self._list_security_monitoring_rules_endpoint.call_with_http_info(**kwargs)
 
-    def list_security_monitoring_signals(self, **kwargs):
+    def list_security_monitoring_signals(
+        self,
+        *,
+        filter_query: Union[str, UnsetType] = unset,
+        filter_from: Union[datetime, UnsetType] = unset,
+        filter_to: Union[datetime, UnsetType] = unset,
+        sort: Union[SecurityMonitoringSignalsSort, UnsetType] = unset,
+        page_cursor: Union[str, UnsetType] = unset,
+        page_limit: Union[int, UnsetType] = unset,
+    ) -> SecurityMonitoringSignalsListResponse:
         """Get a quick list of security signals.
 
         The list endpoint returns security signals that match a search query.
@@ -474,6 +526,25 @@ class SecurityMonitoringApi:
         :type page_limit: int, optional
         :rtype: SecurityMonitoringSignalsListResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if filter_query is not unset:
+            kwargs["filter_query"] = filter_query
+
+        if filter_from is not unset:
+            kwargs["filter_from"] = filter_from
+
+        if filter_to is not unset:
+            kwargs["filter_to"] = filter_to
+
+        if sort is not unset:
+            kwargs["sort"] = sort
+
+        if page_cursor is not unset:
+            kwargs["page_cursor"] = page_cursor
+
+        if page_limit is not unset:
+            kwargs["page_limit"] = page_limit
+
         return self._list_security_monitoring_signals_endpoint.call_with_http_info(**kwargs)
 
     def list_security_monitoring_signals_with_pagination(self, **kwargs):
@@ -510,7 +581,11 @@ class SecurityMonitoringApi:
                 kwargs, "page_cursor", get_attribute_from_path(response, "meta.page.after"), endpoint.params_map
             )
 
-    def search_security_monitoring_signals(self, **kwargs):
+    def search_security_monitoring_signals(
+        self,
+        *,
+        body: Union[SecurityMonitoringSignalListRequest, UnsetType] = unset,
+    ) -> SecurityMonitoringSignalsListResponse:
         """Get a list of security signals.
 
         Returns security signals that match a search query.
@@ -520,6 +595,10 @@ class SecurityMonitoringApi:
         :type body: SecurityMonitoringSignalListRequest, optional
         :rtype: SecurityMonitoringSignalsListResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if body is not unset:
+            kwargs["body"] = body
+
         return self._search_security_monitoring_signals_endpoint.call_with_http_info(**kwargs)
 
     def search_security_monitoring_signals_with_pagination(self, **kwargs):
@@ -545,7 +624,11 @@ class SecurityMonitoringApi:
                 kwargs, "body.page.cursor", get_attribute_from_path(response, "meta.page.after"), endpoint.params_map
             )
 
-    def update_security_filter(self, security_filter_id, body, **kwargs):
+    def update_security_filter(
+        self,
+        security_filter_id: str,
+        body: SecurityFilterUpdateRequest,
+    ) -> SecurityFilterResponse:
         """Update a security filter.
 
         Update a specific security filter.
@@ -557,13 +640,18 @@ class SecurityMonitoringApi:
         :type body: SecurityFilterUpdateRequest
         :rtype: SecurityFilterResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["security_filter_id"] = security_filter_id
 
         kwargs["body"] = body
 
         return self._update_security_filter_endpoint.call_with_http_info(**kwargs)
 
-    def update_security_monitoring_rule(self, rule_id, body, **kwargs):
+    def update_security_monitoring_rule(
+        self,
+        rule_id: str,
+        body: SecurityMonitoringRuleUpdatePayload,
+    ) -> SecurityMonitoringRuleResponse:
         """Update an existing rule.
 
         Update an existing rule. When updating ``cases`` , ``queries`` or ``options`` , the whole field
@@ -575,6 +663,7 @@ class SecurityMonitoringApi:
         :type body: SecurityMonitoringRuleUpdatePayload
         :rtype: SecurityMonitoringRuleResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["rule_id"] = rule_id
 
         kwargs["body"] = body

--- a/src/datadog_api_client/v2/api/service_accounts_api.py
+++ b/src/datadog_api_client/v2/api/service_accounts_api.py
@@ -1,9 +1,15 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
+from datadog_api_client.model_utils import (
+    UnsetType,
+    unset,
+)
 from datadog_api_client.v2.model.list_application_keys_response import ListApplicationKeysResponse
 from datadog_api_client.v2.model.application_keys_sort import ApplicationKeysSort
 from datadog_api_client.v2.model.application_key_response import ApplicationKeyResponse
@@ -199,7 +205,11 @@ class ServiceAccountsApi:
             api_client=api_client,
         )
 
-    def create_service_account_application_key(self, service_account_id, body, **kwargs):
+    def create_service_account_application_key(
+        self,
+        service_account_id: str,
+        body: ApplicationKeyCreateRequest,
+    ) -> ApplicationKeyResponse:
         """Create an application key for this service account.
 
         Create an application key for this service account.
@@ -209,13 +219,18 @@ class ServiceAccountsApi:
         :type body: ApplicationKeyCreateRequest
         :rtype: ApplicationKeyResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["service_account_id"] = service_account_id
 
         kwargs["body"] = body
 
         return self._create_service_account_application_key_endpoint.call_with_http_info(**kwargs)
 
-    def delete_service_account_application_key(self, service_account_id, app_key_id, **kwargs):
+    def delete_service_account_application_key(
+        self,
+        service_account_id: str,
+        app_key_id: str,
+    ) -> None:
         """Delete an application key for this service account.
 
         Delete an application key owned by this service account.
@@ -226,13 +241,18 @@ class ServiceAccountsApi:
         :type app_key_id: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["service_account_id"] = service_account_id
 
         kwargs["app_key_id"] = app_key_id
 
         return self._delete_service_account_application_key_endpoint.call_with_http_info(**kwargs)
 
-    def get_service_account_application_key(self, service_account_id, app_key_id, **kwargs):
+    def get_service_account_application_key(
+        self,
+        service_account_id: str,
+        app_key_id: str,
+    ) -> PartialApplicationKeyResponse:
         """Get one application key for this service account.
 
         Get an application key owned by this service account.
@@ -243,13 +263,24 @@ class ServiceAccountsApi:
         :type app_key_id: str
         :rtype: PartialApplicationKeyResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["service_account_id"] = service_account_id
 
         kwargs["app_key_id"] = app_key_id
 
         return self._get_service_account_application_key_endpoint.call_with_http_info(**kwargs)
 
-    def list_service_account_application_keys(self, service_account_id, **kwargs):
+    def list_service_account_application_keys(
+        self,
+        service_account_id: str,
+        *,
+        page_size: Union[int, UnsetType] = unset,
+        page_number: Union[int, UnsetType] = unset,
+        sort: Union[ApplicationKeysSort, UnsetType] = unset,
+        filter: Union[str, UnsetType] = unset,
+        filter_created_at_start: Union[str, UnsetType] = unset,
+        filter_created_at_end: Union[str, UnsetType] = unset,
+    ) -> ListApplicationKeysResponse:
         """List application keys for this service account.
 
         List all application keys available for this service account.
@@ -272,11 +303,35 @@ class ServiceAccountsApi:
         :type filter_created_at_end: str, optional
         :rtype: ListApplicationKeysResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["service_account_id"] = service_account_id
+
+        if page_size is not unset:
+            kwargs["page_size"] = page_size
+
+        if page_number is not unset:
+            kwargs["page_number"] = page_number
+
+        if sort is not unset:
+            kwargs["sort"] = sort
+
+        if filter is not unset:
+            kwargs["filter"] = filter
+
+        if filter_created_at_start is not unset:
+            kwargs["filter_created_at_start"] = filter_created_at_start
+
+        if filter_created_at_end is not unset:
+            kwargs["filter_created_at_end"] = filter_created_at_end
 
         return self._list_service_account_application_keys_endpoint.call_with_http_info(**kwargs)
 
-    def update_service_account_application_key(self, service_account_id, app_key_id, body, **kwargs):
+    def update_service_account_application_key(
+        self,
+        service_account_id: str,
+        app_key_id: str,
+        body: ApplicationKeyUpdateRequest,
+    ) -> PartialApplicationKeyResponse:
         """Edit an application key for this service account.
 
         Edit an application key owned by this service account.
@@ -288,6 +343,7 @@ class ServiceAccountsApi:
         :type body: ApplicationKeyUpdateRequest
         :rtype: PartialApplicationKeyResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["service_account_id"] = service_account_id
 
         kwargs["app_key_id"] = app_key_id

--- a/src/datadog_api_client/v2/api/usage_metering_api.py
+++ b/src/datadog_api_client/v2/api/usage_metering_api.py
@@ -1,11 +1,15 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
 from datadog_api_client.model_utils import (
     datetime,
+    UnsetType,
+    unset,
 )
 from datadog_api_client.v2.model.usage_application_security_monitoring_response import (
     UsageApplicationSecurityMonitoringResponse,
@@ -193,7 +197,12 @@ class UsageMeteringApi:
             api_client=api_client,
         )
 
-    def get_cost_by_org(self, start_month, **kwargs):
+    def get_cost_by_org(
+        self,
+        start_month: datetime,
+        *,
+        end_month: Union[datetime, UnsetType] = unset,
+    ) -> CostByOrgResponse:
         """Get cost across multi-org account.
 
         Get cost across multi-org account. Cost by org data for a given month becomes available no later than the 16th of the following month.
@@ -204,10 +213,15 @@ class UsageMeteringApi:
         :type end_month: datetime, optional
         :rtype: CostByOrgResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_month"] = start_month
+
+        if end_month is not unset:
+            kwargs["end_month"] = end_month
 
         return self._get_cost_by_org_endpoint.call_with_http_info(**kwargs)
 
+<<<<<<< HEAD
     def get_estimated_cost_by_org(self, **kwargs):
         """Get estimated cost across multi-org account.
 
@@ -226,6 +240,16 @@ class UsageMeteringApi:
         return self._get_estimated_cost_by_org_endpoint.call_with_http_info(**kwargs)
 
     def get_usage_application_security_monitoring(self, start_hr, **kwargs):
+||||||| parent of 59244d222 (Add typing information)
+    def get_usage_application_security_monitoring(self, start_hr, **kwargs):
+=======
+    def get_usage_application_security_monitoring(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageApplicationSecurityMonitoringResponse:
+>>>>>>> 59244d222 (Add typing information)
         """Get hourly usage for Application Security.
 
         Get hourly usage for Application Security .
@@ -237,11 +261,20 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageApplicationSecurityMonitoringResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_application_security_monitoring_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_lambda_traced_invocations(self, start_hr, **kwargs):
+    def get_usage_lambda_traced_invocations(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageLambdaTracedInvocationsResponse:
         """Get hourly usage for Lambda Traced Invocations.
 
         Get hourly usage for Lambda Traced Invocations.
@@ -253,11 +286,20 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageLambdaTracedInvocationsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_lambda_traced_invocations_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_observability_pipelines(self, start_hr, **kwargs):
+    def get_usage_observability_pipelines(
+        self,
+        start_hr: datetime,
+        *,
+        end_hr: Union[datetime, UnsetType] = unset,
+    ) -> UsageObservabilityPipelinesResponse:
         """Get hourly usage for Observability Pipelines.
 
         Get hourly usage for Observability Pipelines.
@@ -269,6 +311,10 @@ class UsageMeteringApi:
         :type end_hr: datetime, optional
         :rtype: UsageObservabilityPipelinesResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["start_hr"] = start_hr
+
+        if end_hr is not unset:
+            kwargs["end_hr"] = end_hr
 
         return self._get_usage_observability_pipelines_endpoint.call_with_http_info(**kwargs)

--- a/src/datadog_api_client/v2/api/usage_metering_api.py
+++ b/src/datadog_api_client/v2/api/usage_metering_api.py
@@ -221,8 +221,14 @@ class UsageMeteringApi:
 
         return self._get_cost_by_org_endpoint.call_with_http_info(**kwargs)
 
-<<<<<<< HEAD
-    def get_estimated_cost_by_org(self, **kwargs):
+    def get_estimated_cost_by_org(
+        self,
+        *,
+        start_month: Union[datetime, UnsetType] = unset,
+        end_month: Union[datetime, UnsetType] = unset,
+        start_date: Union[datetime, UnsetType] = unset,
+        end_date: Union[datetime, UnsetType] = unset,
+    ) -> CostByOrgResponse:
         """Get estimated cost across multi-org account.
 
         Get estimated cost across multi-org account.
@@ -237,19 +243,27 @@ class UsageMeteringApi:
         :type end_date: datetime, optional
         :rtype: CostByOrgResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if start_month is not unset:
+            kwargs["start_month"] = start_month
+
+        if end_month is not unset:
+            kwargs["end_month"] = end_month
+
+        if start_date is not unset:
+            kwargs["start_date"] = start_date
+
+        if end_date is not unset:
+            kwargs["end_date"] = end_date
+
         return self._get_estimated_cost_by_org_endpoint.call_with_http_info(**kwargs)
 
-    def get_usage_application_security_monitoring(self, start_hr, **kwargs):
-||||||| parent of 59244d222 (Add typing information)
-    def get_usage_application_security_monitoring(self, start_hr, **kwargs):
-=======
     def get_usage_application_security_monitoring(
         self,
         start_hr: datetime,
         *,
         end_hr: Union[datetime, UnsetType] = unset,
     ) -> UsageApplicationSecurityMonitoringResponse:
->>>>>>> 59244d222 (Add typing information)
         """Get hourly usage for Application Security.
 
         Get hourly usage for Application Security .

--- a/src/datadog_api_client/v2/api/users_api.py
+++ b/src/datadog_api_client/v2/api/users_api.py
@@ -1,9 +1,15 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019-Present Datadog, Inc.
+from __future__ import annotations
 
+from typing import Any, Dict, Union
 
 from datadog_api_client.api_client import ApiClient, Endpoint as _Endpoint
+from datadog_api_client.model_utils import (
+    UnsetType,
+    unset,
+)
 from datadog_api_client.v2.model.user_response import UserResponse
 from datadog_api_client.v2.model.service_account_create_request import ServiceAccountCreateRequest
 from datadog_api_client.v2.model.user_invitations_response import UserInvitationsResponse
@@ -290,7 +296,10 @@ class UsersApi:
             api_client=api_client,
         )
 
-    def create_service_account(self, body, **kwargs):
+    def create_service_account(
+        self,
+        body: ServiceAccountCreateRequest,
+    ) -> UserResponse:
         """Create a service account.
 
         Create a service account for your organization.
@@ -298,11 +307,15 @@ class UsersApi:
         :type body: ServiceAccountCreateRequest
         :rtype: UserResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_service_account_endpoint.call_with_http_info(**kwargs)
 
-    def create_user(self, body, **kwargs):
+    def create_user(
+        self,
+        body: UserCreateRequest,
+    ) -> UserResponse:
         """Create a user.
 
         Create a user for your organization.
@@ -310,11 +323,15 @@ class UsersApi:
         :type body: UserCreateRequest
         :rtype: UserResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._create_user_endpoint.call_with_http_info(**kwargs)
 
-    def disable_user(self, user_id, **kwargs):
+    def disable_user(
+        self,
+        user_id: str,
+    ) -> None:
         """Disable a user.
 
         Disable a user. Can only be used with an application key belonging
@@ -324,11 +341,15 @@ class UsersApi:
         :type user_id: str
         :rtype: None
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["user_id"] = user_id
 
         return self._disable_user_endpoint.call_with_http_info(**kwargs)
 
-    def get_invitation(self, user_invitation_uuid, **kwargs):
+    def get_invitation(
+        self,
+        user_invitation_uuid: str,
+    ) -> UserInvitationResponse:
         """Get a user invitation.
 
         Returns a single user invitation by its UUID.
@@ -337,11 +358,15 @@ class UsersApi:
         :type user_invitation_uuid: str
         :rtype: UserInvitationResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["user_invitation_uuid"] = user_invitation_uuid
 
         return self._get_invitation_endpoint.call_with_http_info(**kwargs)
 
-    def get_user(self, user_id, **kwargs):
+    def get_user(
+        self,
+        user_id: str,
+    ) -> UserResponse:
         """Get user details.
 
         Get a user in the organization specified by the user’s ``user_id``.
@@ -350,11 +375,15 @@ class UsersApi:
         :type user_id: str
         :rtype: UserResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["user_id"] = user_id
 
         return self._get_user_endpoint.call_with_http_info(**kwargs)
 
-    def list_user_organizations(self, user_id, **kwargs):
+    def list_user_organizations(
+        self,
+        user_id: str,
+    ) -> UserResponse:
         """Get a user organization.
 
         Get a user organization. Returns the user information and all organizations
@@ -364,11 +393,15 @@ class UsersApi:
         :type user_id: str
         :rtype: UserResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["user_id"] = user_id
 
         return self._list_user_organizations_endpoint.call_with_http_info(**kwargs)
 
-    def list_user_permissions(self, user_id, **kwargs):
+    def list_user_permissions(
+        self,
+        user_id: str,
+    ) -> PermissionsResponse:
         """Get a user permissions.
 
         Get a user permission set. Returns a list of the user’s permissions
@@ -378,11 +411,21 @@ class UsersApi:
         :type user_id: str
         :rtype: PermissionsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["user_id"] = user_id
 
         return self._list_user_permissions_endpoint.call_with_http_info(**kwargs)
 
-    def list_users(self, **kwargs):
+    def list_users(
+        self,
+        *,
+        page_size: Union[int, UnsetType] = unset,
+        page_number: Union[int, UnsetType] = unset,
+        sort: Union[str, UnsetType] = unset,
+        sort_dir: Union[QuerySortOrder, UnsetType] = unset,
+        filter: Union[str, UnsetType] = unset,
+        filter_status: Union[str, UnsetType] = unset,
+    ) -> UsersResponse:
         """List all users.
 
         Get the list of all users in the organization. This list includes
@@ -407,9 +450,31 @@ class UsersApi:
         :type filter_status: str, optional
         :rtype: UsersResponse
         """
+        kwargs: Dict[str, Any] = {}
+        if page_size is not unset:
+            kwargs["page_size"] = page_size
+
+        if page_number is not unset:
+            kwargs["page_number"] = page_number
+
+        if sort is not unset:
+            kwargs["sort"] = sort
+
+        if sort_dir is not unset:
+            kwargs["sort_dir"] = sort_dir
+
+        if filter is not unset:
+            kwargs["filter"] = filter
+
+        if filter_status is not unset:
+            kwargs["filter_status"] = filter_status
+
         return self._list_users_endpoint.call_with_http_info(**kwargs)
 
-    def send_invitations(self, body, **kwargs):
+    def send_invitations(
+        self,
+        body: UserInvitationsRequest,
+    ) -> UserInvitationsResponse:
         """Send invitation emails.
 
         Sends emails to one or more users inviting them to join the organization.
@@ -417,11 +482,16 @@ class UsersApi:
         :type body: UserInvitationsRequest
         :rtype: UserInvitationsResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["body"] = body
 
         return self._send_invitations_endpoint.call_with_http_info(**kwargs)
 
-    def update_user(self, user_id, body, **kwargs):
+    def update_user(
+        self,
+        user_id: str,
+        body: UserUpdateRequest,
+    ) -> UserResponse:
         """Update a user.
 
         Edit a user. Can only be used with an application key belonging
@@ -432,6 +502,7 @@ class UsersApi:
         :type body: UserUpdateRequest
         :rtype: UserResponse
         """
+        kwargs: Dict[str, Any] = {}
         kwargs["user_id"] = user_id
 
         kwargs["body"] = body


### PR DESCRIPTION
This adds explicit arguments to API method alongside with typing, to return type as well.