### PR TITLE
Fix oneOf primitive objects creation

### DIFF
--- a/.generator/src/generator/templates/model_utils.j2
+++ b/.generator/src/generator/templates/model_utils.j2
@@ -1573,10 +1573,10 @@ def get_oneof_instance(cls, model_kwargs, constant_kwargs, model_arg=None):
                     oneof_instance = validate_and_convert_types(
                         model_arg,
                         (oneof_class,),
-                        constant_kwargs["_path_to_item"],
-                        constant_kwargs["_spec_property_naming"],
-                        constant_kwargs["_check_type"],
-                        configuration=constant_kwargs["_configuration"],
+                        constant_kwargs.get("_path_to_item", ()),
+                        constant_kwargs.get("_spec_property_naming", False),
+                        constant_kwargs.get("_check_type", True),
+                        configuration=constant_kwargs.get("_configuration"),
                     )
                     oneof_instances.append(oneof_instance)
         except Exception:

--- a/src/datadog_api_client/model_utils.py
+++ b/src/datadog_api_client/model_utils.py
@@ -1575,10 +1575,10 @@ def get_oneof_instance(cls, model_kwargs, constant_kwargs, model_arg=None):
                     oneof_instance = validate_and_convert_types(
                         model_arg,
                         (oneof_class,),
-                        constant_kwargs["_path_to_item"],
-                        constant_kwargs["_spec_property_naming"],
-                        constant_kwargs["_check_type"],
-                        configuration=constant_kwargs["_configuration"],
+                        constant_kwargs.get("_path_to_item", ()),
+                        constant_kwargs.get("_spec_property_naming", False),
+                        constant_kwargs.get("_check_type", True),
+                        configuration=constant_kwargs.get("_configuration"),
                     )
                     oneof_instances.append(oneof_instance)
         except Exception:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,6 +1,29 @@
 from datadog_api_client.v1.model.monitor_thresholds import MonitorThresholds
+from datadog_api_client.v2.model.logs_group_by import LogsGroupBy
+from datadog_api_client.v2.model.logs_group_by_missing import LogsGroupByMissing
+from datadog_api_client.v2.model.logs_group_by_total import LogsGroupByTotal
+from datadog_api_client.v2.model.logs_aggregate_sort import LogsAggregateSort
+from datadog_api_client.v2.model.logs_aggregate_sort_type import LogsAggregateSortType
+from datadog_api_client.v2.model.logs_aggregation_function import LogsAggregationFunction
+from datadog_api_client.v2.model.logs_sort_order import LogsSortOrder
 
 
 def test_default_coerce():
     thresholds = MonitorThresholds(critical=5)
     assert thresholds["critical"] == 5.0
+
+
+def test_primitive_one_of():
+    group_by = LogsGroupBy(
+        facet="host",
+        missing=LogsGroupByMissing("miss"),
+        sort=LogsAggregateSort(
+            type=LogsAggregateSortType("measure"),
+            order=LogsSortOrder("asc"),
+            aggregation=LogsAggregationFunction("pc90"),
+            metric="@duration",
+        ),
+        total=LogsGroupByTotal("recall"),
+    )
+
+    assert group_by.missing == "miss"


### PR DESCRIPTION
We were basing the creation on the presence of optional parameters, so
it failed and got an unparsed object.