### PR TITLE
Specify python version 3.10 in Github runner

### DIFF
--- a/.generator/pyproject.toml
+++ b/.generator/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Datadog <support@datadoghq.com>"]
 license = "Apache-2.0"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 click = "8.0.1"
 PyYAML = "6.0"
 jsonref = "0.2"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,9 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ steps.get_token.outputs.token }}
+      - uses: actions/setup-python@v4 
+        with:
+          python-version: '3.10'
       - name: Install pre-commit
         run: python -m pip install pre-commit
       - name: set PY


### PR DESCRIPTION
Newest Poetry version respects python version, which breaks our pre-commit. This PR updates python version in the github runners to use python 3.10+