### PR TITLE
pin pytest-bdd version to 6.0.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ tests =
     glom
     jinja2
     pytest
-    pytest-bdd>=5.0.0
+    pytest-bdd==6.0.1
     pytest-asyncio
     pytest-randomly
     pytest-recording


### PR DESCRIPTION
6.1.0 introduces a breaking change that changes the order of pytest hooks and breaks our tests.