### PR TITLE
Support differing operation tag and undo tag

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -516,8 +516,8 @@ def undo(package_name, undo_operations, client):
 
         # If Undo tag is not the same as the the operation tag.
         # For example, Service Accounts use the DisableUser operation to undo, which is part of Users.
-        if "tags" in operation and operation["base_tag"] != operation["tags"][0]:
-            undo_tag = operation["tags"][0]
+        if "tag" in operation and operation["base_tag"] != operation["tag"]:
+            undo_tag = operation["tag"]
             undo_name = undo_tag.replace(" ", "")
             undo_module_name = snake_case(undo_tag)
             undo_package = importlib.import_module(f"{package_name}.api.{undo_module_name}_api")


### PR DESCRIPTION
Adds a check in the tests to support when the operation tag and undo operation tag differ. This came up when trying to move the CreateServiceAccount endpoint from the Users tag to the Service Accounts tag. The tests currently try to use the `ServiceAccountsApi.disable_user` operation, when it needs to find the `UsersApi.disable_user` op.