### PR TITLE
Pin aiosonic due to issue with its dependency onecache 0.4.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ setup_requires =
 apm =
     ddtrace>=1.2.0
 async =
-    aiosonic
+    aiosonic==0.15.1
 zstandard =
     zstandard
 tests =

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ async =
 zstandard =
     zstandard
 tests =
-    aiosonic
+    aiosonic==0.15.1
     glom
     jinja2
     pytest


### PR DESCRIPTION
onecache 0.4.1 is not building properly, seems like the newer version is not python 3.11 compatible but the older one was.
aiosonic 0.16.0 depends on onecache 0.4.1, so instead pin aiosonic to the previous version.