### PR TITLE
Handle dict keys with special characters

### DIFF
--- a/.generator/src/generator/formatter.py
+++ b/.generator/src/generator/formatter.py
@@ -351,7 +351,8 @@ def format_data_with_schema_dict(
             warnings.warn(f"[{matched}] {data} is not valid for schema {name}")
 
     if not parameters and data:
-        parameters = ", ".join(f'{k}="{v}"' for k, v in data.items())
+        key_val_pairs = ", ".join(f'("{k}", "{v}")' for k, v in data.items())
+        parameters = f"[{key_val_pairs}]"
 
     if name:
         return f"{name}({parameters})", imports


### PR DESCRIPTION
Prevent the example generation from breaking when dictionary keys have special characters.

Example (from https://github.com/DataDog/datadog-api-spec/pull/2117)
https://github.com/DataDog/datadog-api-client-python/blob/d13a9efb5d43b8e750b351346a878c3b95b6f0f3/examples/v2/service-definition/CreateOrUpdateServiceDefinitions.py#L29