### PR TITLE
Fix ddtrace pin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ setup_requires =
 
 [options.extras_require]
 apm =
-    ddtrace>=1.2.0,<1.3.0
+    ddtrace>=1.2.0,<1.13.0
 async =
     aiosonic==0.15.1
 zstandard =


### PR DESCRIPTION
Was pinned to a very old version of ddtrace, instead of to 1.12