### PR TITLE
Handle `{}` and `bool` for additionalProperties

### DIFF
--- a/.generator/src/generator/templates/model_generic.j2
+++ b/.generator/src/generator/templates/model_generic.j2
@@ -54,7 +54,7 @@ class {{ name }}(ModelNormal):
     }
 {%- endif %}
 
-{%- if model.get("additionalProperties") %}
+{%- if model.get("additionalProperties", false) is not false %}
     @cached_property
     def additional_properties_type(_):
 {%- if refs %}


### PR DESCRIPTION
We need to handle both empty object and boolean value for additionalProperties:

```
schema:
  additionalProperties: {}
---------------------------
schema:
  additionalProperties: true
```