### PR TITLE
 Pass SSL configuration arguments to Async Api Client

### DIFF
--- a/.generator/src/generator/templates/rest.j2
+++ b/.generator/src/generator/templates/rest.j2
@@ -238,7 +238,7 @@ class AsyncRESTClientObject:
         proxy = None
         if configuration.proxy:
             proxy = aiosonic.Proxy(configuration.proxy, configuration.proxy_headers)
-        self._client = aiosonic.HTTPClient(proxy=proxy)
+        self._client = aiosonic.HTTPClient(proxy=proxy, verify_ssl=configuration.verify_ssl)
         self._configuration = configuration
 
     def _retry(self, method, response, counter):

--- a/src/datadog_api_client/rest.py
+++ b/src/datadog_api_client/rest.py
@@ -240,7 +240,7 @@ class AsyncRESTClientObject:
         proxy = None
         if configuration.proxy:
             proxy = aiosonic.Proxy(configuration.proxy, configuration.proxy_headers)
-        self._client = aiosonic.HTTPClient(proxy=proxy)
+        self._client = aiosonic.HTTPClient(proxy=proxy, verify_ssl=configuration.verify_ssl)
         self._configuration = configuration
 
     def _retry(self, method, response, counter):


### PR DESCRIPTION
### SSL Configuration Arguments Not Passed to Async Api Client

The current datadog api client fails to pass ssl_verify argument to the AsyncApiClient which will result in 
`self._sslobj.do_handshake()
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1002)` 

Linked Issue: https://github.com/DataDog/datadog-api-client-python/issues/1654