### PR TITLE
Pass all keyword/ arguments to avoid panics with `setuptools_scm` > 8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     typing-extensions
 setup_requires =
     setuptools>=30.3.0
-    setuptools_scm<8
+    setuptools_scm
 
 [options.extras_require]
 apm =

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,12 @@ __version__ = "{version}"
 
 # Allows the fetching of tags even from shallow clones
 # https://github.com/pypa/setuptools_scm/pull/118#issuecomment-255381535
-def parse_fetch_on_shallow(root):
+def parse_fetch_on_shallow(*args, **kwargs):
     from setuptools_scm.git import parse, fetch_on_shallow
 
-    return parse(root, pre_parse=fetch_on_shallow)
+    kwargs["pre_parse"] = fetch_on_shallow
+
+    return parse(*args, **kwargs)
 
 
 setup(


### PR DESCRIPTION
Avoid panics such as:

```
TypeError: parse_fetch_on_shallow() got an unexpected keyword argument 'config'
```