### PR TITLE
Add minimal typing_extensions version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     urllib3>=1.15
     certifi
     python-dateutil
-    typing-extensions
+    typing-extensions>=4.0.0
 setup_requires =
     setuptools>=30.3.0
     setuptools_scm


### PR DESCRIPTION
We need it for the `Self` definition if you're not on python 3.11.

Fixes #1727