### PR TITLE
Pin pytest below 8.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ tests =
     aiosonic==0.15.1
     glom
     jinja2
-    pytest
+    pytest<8.0.0
     pytest-bdd==6.0.1
     pytest-asyncio
     pytest-randomly


### PR DESCRIPTION
ddtrace is incompatible with pytest 8, pin this until a fix is released.