### PR TITLE
Fix step name

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -699,7 +699,7 @@ def expect_response_has_field(context, response_path, field):
     assert field in response_value
 
 
-@then(parsers.parse('the response "{response_path}" does not have "{field}"'))
+@then(parsers.parse('the response "{response_path}" does not have field "{field}"'))
 def expect_response_does_not_have_field(context, response_path, field):
     """Check that a response path does not have field."""
     response_value = glom(context["api_request"]["response"][0], response_path)


### PR DESCRIPTION
Follow up to https://github.com/DataDog/datadog-api-client-python/pull/1901 because I misspelled the name of the step. It's defined here:
https://github.com/DataDog/datadog-api-client-python/blob/fe7a9a63e7470c1b0e62b0cc8a61cb0ce0653c2a/.generator/conftest.py#L541-L543

### Review checklist

Please check relevant items below:

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [x] This PR does not rely on API client schema changes.
  - [x] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.
