### PR TITLE
Enable additionalProperties by default

### DIFF
--- a/.generator/src/generator/openapi.py
+++ b/.generator/src/generator/openapi.py
@@ -67,6 +67,10 @@ def basic_type_to_python(type_, schema, typing=False):
 def type_to_python(schema, typing=False):
     """Return Python type name for the type."""
 
+    # Special case for additionalProperties: True
+    if schema is True:
+        return basic_type_to_python(None, {}, typing=typing)
+
     name = formatter.get_name(schema)
 
     if "oneOf" in schema:

--- a/.generator/src/generator/templates/model_generic.j2
+++ b/.generator/src/generator/templates/model_generic.j2
@@ -56,7 +56,7 @@ class {{ name }}(ModelNormal):
 
 {%- set additionalProperties = model.get("additionalProperties") %}
 {#- Only add additional_properties_type property if additionalProperties is disabled or has a custom type #}
-{%- if (additionalProperties and additionalProperties is not true) or additionalProperties is false %}
+{%- if (additionalProperties is false) or (additionalProperties and additionalProperties is not true) %}
     @cached_property
     def additional_properties_type(_):
 {%- if additionalProperties is false %}

--- a/.generator/src/generator/templates/model_generic.j2
+++ b/.generator/src/generator/templates/model_generic.j2
@@ -54,7 +54,8 @@ class {{ name }}(ModelNormal):
     }
 {%- endif %}
 
-{%- if model.get("additionalProperties", false) is not false %}
+{%- set additionalProperties = model.get("additionalProperties", false) %}
+{%- if additionalProperties is not false %}
     @cached_property
     def additional_properties_type(_):
 {%- if refs %}
@@ -62,7 +63,7 @@ class {{ name }}(ModelNormal):
         from {{ package }}.{{ version }}.model.{{ ref|safe_snake_case }} import {{ ref }}
 {%- endfor %}
 {%- endif %}
-        return ({{ type_to_python(model["additionalProperties"]) }},)
+        return ({{ type_to_python(additionalProperties) }},)
 {%- endif %}
 
 {%- if model.nullable %}

--- a/.generator/src/generator/templates/model_generic.j2
+++ b/.generator/src/generator/templates/model_generic.j2
@@ -54,16 +54,21 @@ class {{ name }}(ModelNormal):
     }
 {%- endif %}
 
-{%- set additionalProperties = model.get("additionalProperties", true) %}
-{%- if additionalProperties is not false %}
+{%- set additionalProperties = model.get("additionalProperties") %}
+{#- Only add additional_properties_type property if additionalProperties is disabled or has a custom type #}
+{%- if (additionalProperties and additionalProperties is not true) or additionalProperties is false %}
     @cached_property
     def additional_properties_type(_):
+{%- if additionalProperties is false %}
+        return None
+{%- else -%}
 {%- if refs %}
 {%- for ref in refs %}
         from {{ package }}.{{ version }}.model.{{ ref|safe_snake_case }} import {{ ref }}
 {%- endfor %}
 {%- endif %}
-        return ({{ type_to_python(additionalProperties) }},)
+        return ({{ type_to_python(model["additionalProperties"]) }},)
+{%- endif %}
 {%- endif %}
 
 {%- if model.nullable %}

--- a/.generator/src/generator/templates/model_generic.j2
+++ b/.generator/src/generator/templates/model_generic.j2
@@ -54,7 +54,7 @@ class {{ name }}(ModelNormal):
     }
 {%- endif %}
 
-{%- set additionalProperties = model.get("additionalProperties", false) %}
+{%- set additionalProperties = model.get("additionalProperties", true) %}
 {%- if additionalProperties is not false %}
     @cached_property
     def additional_properties_type(_):

--- a/.generator/src/generator/templates/model_utils.j2
+++ b/.generator/src/generator/templates/model_utils.j2
@@ -393,16 +393,6 @@ class ModelNormal(OpenApiModel):
     def __init__(self, kwargs):
         super().__init__(kwargs)
         for var_name, var_value in kwargs.items():
-            if (
-                var_name not in self.attribute_map
-                and self._configuration is not None
-                and self._configuration.discard_unknown_keys
-                and self.additional_properties_type is not None
-            ):
-                if self._spec_property_naming:
-                    # If it's returned from the API, store it if we need to send it back
-                    self.__dict__["_data_store"][var_name] = var_value
-                continue
             setattr(self, var_name, var_value)
             if not self._spec_property_naming and var_name in self.read_only_vars:
                 raise ApiAttributeError(f"`{var_name}` is a read-only attribute.")

--- a/.generator/src/generator/templates/model_utils.j2
+++ b/.generator/src/generator/templates/model_utils.j2
@@ -397,7 +397,7 @@ class ModelNormal(OpenApiModel):
                 var_name not in self.attribute_map
                 and self._configuration is not None
                 and self._configuration.discard_unknown_keys
-                and self.additional_properties_type is None
+                and self.additional_properties_type is not None
             ):
                 if self._spec_property_naming:
                     # If it's returned from the API, store it if we need to send it back

--- a/.generator/src/generator/templates/model_utils.j2
+++ b/.generator/src/generator/templates/model_utils.j2
@@ -107,7 +107,7 @@ class OpenApiModel(object):
 
     _composed_schemas = empty_dict
 
-    additional_properties_type = None
+    additional_properties_type = ({{ type_to_python(True) }},)
 
     attribute_map: Mapping[str, str] = empty_dict
 

--- a/src/datadog_api_client/model_utils.py
+++ b/src/datadog_api_client/model_utils.py
@@ -406,16 +406,6 @@ class ModelNormal(OpenApiModel):
     def __init__(self, kwargs):
         super().__init__(kwargs)
         for var_name, var_value in kwargs.items():
-            if (
-                var_name not in self.attribute_map
-                and self._configuration is not None
-                and self._configuration.discard_unknown_keys
-                and self.additional_properties_type is not None
-            ):
-                if self._spec_property_naming:
-                    # If it's returned from the API, store it if we need to send it back
-                    self.__dict__["_data_store"][var_name] = var_value
-                continue
             setattr(self, var_name, var_value)
             if not self._spec_property_naming and var_name in self.read_only_vars:
                 raise ApiAttributeError(f"`{var_name}` is a read-only attribute.")

--- a/src/datadog_api_client/model_utils.py
+++ b/src/datadog_api_client/model_utils.py
@@ -109,7 +109,18 @@ class OpenApiModel(object):
 
     _composed_schemas = empty_dict
 
-    additional_properties_type = None
+    additional_properties_type = (
+        bool,
+        date,
+        datetime,
+        dict,
+        float,
+        int,
+        list,
+        str,
+        UUID,
+        none_type,
+    )
 
     attribute_map: Mapping[str, str] = empty_dict
 
@@ -399,7 +410,7 @@ class ModelNormal(OpenApiModel):
                 var_name not in self.attribute_map
                 and self._configuration is not None
                 and self._configuration.discard_unknown_keys
-                and self.additional_properties_type is None
+                and self.additional_properties_type is not None
             ):
                 if self._spec_property_naming:
                     # If it's returned from the API, store it if we need to send it back

--- a/src/datadog_api_client/v1/model/notebook_cell_create_request.py
+++ b/src/datadog_api_client/v1/model/notebook_cell_create_request.py
@@ -24,6 +24,10 @@ if TYPE_CHECKING:
 
 class NotebookCellCreateRequest(ModelNormal):
     @cached_property
+    def additional_properties_type(_):
+        return None
+
+    @cached_property
     def openapi_types(_):
         from datadog_api_client.v1.model.notebook_cell_create_request_attributes import (
             NotebookCellCreateRequestAttributes,

--- a/src/datadog_api_client/v1/model/slo_time_slice_spec.py
+++ b/src/datadog_api_client/v1/model/slo_time_slice_spec.py
@@ -17,6 +17,10 @@ if TYPE_CHECKING:
 
 class SLOTimeSliceSpec(ModelNormal):
     @cached_property
+    def additional_properties_type(_):
+        return None
+
+    @cached_property
     def openapi_types(_):
         from datadog_api_client.v1.model.slo_time_slice_condition import SLOTimeSliceCondition
 

--- a/src/datadog_api_client/v2/model/bulk_mute_findings_request_attributes.py
+++ b/src/datadog_api_client/v2/model/bulk_mute_findings_request_attributes.py
@@ -17,6 +17,10 @@ if TYPE_CHECKING:
 
 class BulkMuteFindingsRequestAttributes(ModelNormal):
     @cached_property
+    def additional_properties_type(_):
+        return None
+
+    @cached_property
     def openapi_types(_):
         from datadog_api_client.v2.model.bulk_mute_findings_request_properties import BulkMuteFindingsRequestProperties
 

--- a/src/datadog_api_client/v2/model/bulk_mute_findings_request_properties.py
+++ b/src/datadog_api_client/v2/model/bulk_mute_findings_request_properties.py
@@ -19,6 +19,10 @@ if TYPE_CHECKING:
 
 class BulkMuteFindingsRequestProperties(ModelNormal):
     @cached_property
+    def additional_properties_type(_):
+        return None
+
+    @cached_property
     def openapi_types(_):
         from datadog_api_client.v2.model.finding_mute_reason import FindingMuteReason
 

--- a/src/datadog_api_client/v2/model/cloud_configuration_compliance_rule_options.py
+++ b/src/datadog_api_client/v2/model/cloud_configuration_compliance_rule_options.py
@@ -8,12 +8,8 @@ from typing import Union, TYPE_CHECKING
 from datadog_api_client.model_utils import (
     ModelNormal,
     cached_property,
-    date,
-    datetime,
-    none_type,
     unset,
     UnsetType,
-    UUID,
 )
 
 
@@ -22,21 +18,6 @@ if TYPE_CHECKING:
 
 
 class CloudConfigurationComplianceRuleOptions(ModelNormal):
-    @cached_property
-    def additional_properties_type(_):
-        return (
-            bool,
-            date,
-            datetime,
-            dict,
-            float,
-            int,
-            list,
-            str,
-            UUID,
-            none_type,
-        )
-
     @cached_property
     def openapi_types(_):
         from datadog_api_client.v2.model.cloud_configuration_rego_rule import CloudConfigurationRegoRule

--- a/src/datadog_api_client/v2/model/downtime_monitor_identifier_id.py
+++ b/src/datadog_api_client/v2/model/downtime_monitor_identifier_id.py
@@ -7,29 +7,10 @@ from __future__ import annotations
 from datadog_api_client.model_utils import (
     ModelNormal,
     cached_property,
-    date,
-    datetime,
-    none_type,
-    UUID,
 )
 
 
 class DowntimeMonitorIdentifierId(ModelNormal):
-    @cached_property
-    def additional_properties_type(_):
-        return (
-            bool,
-            date,
-            datetime,
-            dict,
-            float,
-            int,
-            list,
-            str,
-            UUID,
-            none_type,
-        )
-
     @cached_property
     def openapi_types(_):
         return {

--- a/src/datadog_api_client/v2/model/downtime_monitor_identifier_tags.py
+++ b/src/datadog_api_client/v2/model/downtime_monitor_identifier_tags.py
@@ -8,10 +8,6 @@ from typing import List
 from datadog_api_client.model_utils import (
     ModelNormal,
     cached_property,
-    date,
-    datetime,
-    none_type,
-    UUID,
 )
 
 
@@ -21,21 +17,6 @@ class DowntimeMonitorIdentifierTags(ModelNormal):
             "min_items": 1,
         },
     }
-
-    @cached_property
-    def additional_properties_type(_):
-        return (
-            bool,
-            date,
-            datetime,
-            dict,
-            float,
-            int,
-            list,
-            str,
-            UUID,
-            none_type,
-        )
 
     @cached_property
     def openapi_types(_):

--- a/src/datadog_api_client/v2/model/downtime_schedule_one_time_create_update_request.py
+++ b/src/datadog_api_client/v2/model/downtime_schedule_one_time_create_update_request.py
@@ -17,6 +17,10 @@ from datadog_api_client.model_utils import (
 
 class DowntimeScheduleOneTimeCreateUpdateRequest(ModelNormal):
     @cached_property
+    def additional_properties_type(_):
+        return None
+
+    @cached_property
     def openapi_types(_):
         return {
             "end": (datetime, none_type),

--- a/src/datadog_api_client/v2/model/downtime_schedule_recurrence_create_update_request.py
+++ b/src/datadog_api_client/v2/model/downtime_schedule_recurrence_create_update_request.py
@@ -8,31 +8,13 @@ from typing import Union
 from datadog_api_client.model_utils import (
     ModelNormal,
     cached_property,
-    date,
-    datetime,
     none_type,
     unset,
     UnsetType,
-    UUID,
 )
 
 
 class DowntimeScheduleRecurrenceCreateUpdateRequest(ModelNormal):
-    @cached_property
-    def additional_properties_type(_):
-        return (
-            bool,
-            date,
-            datetime,
-            dict,
-            float,
-            int,
-            list,
-            str,
-            UUID,
-            none_type,
-        )
-
     @cached_property
     def openapi_types(_):
         return {

--- a/src/datadog_api_client/v2/model/downtime_schedule_recurrences_update_request.py
+++ b/src/datadog_api_client/v2/model/downtime_schedule_recurrences_update_request.py
@@ -21,6 +21,10 @@ if TYPE_CHECKING:
 
 class DowntimeScheduleRecurrencesUpdateRequest(ModelNormal):
     @cached_property
+    def additional_properties_type(_):
+        return None
+
+    @cached_property
     def openapi_types(_):
         from datadog_api_client.v2.model.downtime_schedule_recurrence_create_update_request import (
             DowntimeScheduleRecurrenceCreateUpdateRequest,

--- a/src/datadog_api_client/v2/model/finding_mute.py
+++ b/src/datadog_api_client/v2/model/finding_mute.py
@@ -19,6 +19,10 @@ if TYPE_CHECKING:
 
 class FindingMute(ModelNormal):
     @cached_property
+    def additional_properties_type(_):
+        return None
+
+    @cached_property
     def openapi_types(_):
         from datadog_api_client.v2.model.finding_mute_reason import FindingMuteReason
 

--- a/src/datadog_api_client/v2/model/finding_rule.py
+++ b/src/datadog_api_client/v2/model/finding_rule.py
@@ -15,6 +15,10 @@ from datadog_api_client.model_utils import (
 
 class FindingRule(ModelNormal):
     @cached_property
+    def additional_properties_type(_):
+        return None
+
+    @cached_property
     def openapi_types(_):
         return {
             "id": (str,),

--- a/src/datadog_api_client/v2/model/list_findings_meta.py
+++ b/src/datadog_api_client/v2/model/list_findings_meta.py
@@ -25,6 +25,10 @@ class ListFindingsMeta(ModelNormal):
     }
 
     @cached_property
+    def additional_properties_type(_):
+        return None
+
+    @cached_property
     def openapi_types(_):
         from datadog_api_client.v2.model.list_findings_page import ListFindingsPage
 

--- a/src/datadog_api_client/v2/model/list_findings_page.py
+++ b/src/datadog_api_client/v2/model/list_findings_page.py
@@ -15,6 +15,10 @@ from datadog_api_client.model_utils import (
 
 class ListFindingsPage(ModelNormal):
     @cached_property
+    def additional_properties_type(_):
+        return None
+
+    @cached_property
     def openapi_types(_):
         return {
             "cursor": (str,),

--- a/src/datadog_api_client/v2/model/security_monitoring_rule_query_payload_data.py
+++ b/src/datadog_api_client/v2/model/security_monitoring_rule_query_payload_data.py
@@ -8,31 +8,12 @@ from typing import Union
 from datadog_api_client.model_utils import (
     ModelNormal,
     cached_property,
-    date,
-    datetime,
-    none_type,
     unset,
     UnsetType,
-    UUID,
 )
 
 
 class SecurityMonitoringRuleQueryPayloadData(ModelNormal):
-    @cached_property
-    def additional_properties_type(_):
-        return (
-            bool,
-            date,
-            datetime,
-            dict,
-            float,
-            int,
-            list,
-            str,
-            UUID,
-            none_type,
-        )
-
     @cached_property
     def openapi_types(_):
         return {

--- a/src/datadog_api_client/v2/model/security_monitoring_signal_attributes.py
+++ b/src/datadog_api_client/v2/model/security_monitoring_signal_attributes.py
@@ -19,21 +19,6 @@ from datadog_api_client.model_utils import (
 
 class SecurityMonitoringSignalAttributes(ModelNormal):
     @cached_property
-    def additional_properties_type(_):
-        return (
-            bool,
-            date,
-            datetime,
-            dict,
-            float,
-            int,
-            list,
-            str,
-            UUID,
-            none_type,
-        )
-
-    @cached_property
     def openapi_types(_):
         return {
             "custom": (

--- a/src/datadog_api_client/v2/model/workflow_instance_create_response.py
+++ b/src/datadog_api_client/v2/model/workflow_instance_create_response.py
@@ -8,12 +8,8 @@ from typing import Union, TYPE_CHECKING
 from datadog_api_client.model_utils import (
     ModelNormal,
     cached_property,
-    date,
-    datetime,
-    none_type,
     unset,
     UnsetType,
-    UUID,
 )
 
 
@@ -22,21 +18,6 @@ if TYPE_CHECKING:
 
 
 class WorkflowInstanceCreateResponse(ModelNormal):
-    @cached_property
-    def additional_properties_type(_):
-        return (
-            bool,
-            date,
-            datetime,
-            dict,
-            float,
-            int,
-            list,
-            str,
-            UUID,
-            none_type,
-        )
-
     @cached_property
     def openapi_types(_):
         from datadog_api_client.v2.model.workflow_instance_create_response_data import (

--- a/src/datadog_api_client/v2/model/workflow_instance_create_response_data.py
+++ b/src/datadog_api_client/v2/model/workflow_instance_create_response_data.py
@@ -8,31 +8,12 @@ from typing import Union
 from datadog_api_client.model_utils import (
     ModelNormal,
     cached_property,
-    date,
-    datetime,
-    none_type,
     unset,
     UnsetType,
-    UUID,
 )
 
 
 class WorkflowInstanceCreateResponseData(ModelNormal):
-    @cached_property
-    def additional_properties_type(_):
-        return (
-            bool,
-            date,
-            datetime,
-            dict,
-            float,
-            int,
-            list,
-            str,
-            UUID,
-            none_type,
-        )
-
     @cached_property
     def openapi_types(_):
         return {

--- a/src/datadog_api_client/v2/model/workflow_instance_list_item.py
+++ b/src/datadog_api_client/v2/model/workflow_instance_list_item.py
@@ -8,31 +8,12 @@ from typing import Union
 from datadog_api_client.model_utils import (
     ModelNormal,
     cached_property,
-    date,
-    datetime,
-    none_type,
     unset,
     UnsetType,
-    UUID,
 )
 
 
 class WorkflowInstanceListItem(ModelNormal):
-    @cached_property
-    def additional_properties_type(_):
-        return (
-            bool,
-            date,
-            datetime,
-            dict,
-            float,
-            int,
-            list,
-            str,
-            UUID,
-            none_type,
-        )
-
     @cached_property
     def openapi_types(_):
         return {

--- a/src/datadog_api_client/v2/model/workflow_list_instances_response.py
+++ b/src/datadog_api_client/v2/model/workflow_list_instances_response.py
@@ -8,12 +8,8 @@ from typing import List, Union, TYPE_CHECKING
 from datadog_api_client.model_utils import (
     ModelNormal,
     cached_property,
-    date,
-    datetime,
-    none_type,
     unset,
     UnsetType,
-    UUID,
 )
 
 
@@ -23,21 +19,6 @@ if TYPE_CHECKING:
 
 
 class WorkflowListInstancesResponse(ModelNormal):
-    @cached_property
-    def additional_properties_type(_):
-        return (
-            bool,
-            date,
-            datetime,
-            dict,
-            float,
-            int,
-            list,
-            str,
-            UUID,
-            none_type,
-        )
-
     @cached_property
     def openapi_types(_):
         from datadog_api_client.v2.model.workflow_instance_list_item import WorkflowInstanceListItem

--- a/src/datadog_api_client/v2/model/workflow_list_instances_response_meta.py
+++ b/src/datadog_api_client/v2/model/workflow_list_instances_response_meta.py
@@ -8,12 +8,8 @@ from typing import Union, TYPE_CHECKING
 from datadog_api_client.model_utils import (
     ModelNormal,
     cached_property,
-    date,
-    datetime,
-    none_type,
     unset,
     UnsetType,
-    UUID,
 )
 
 
@@ -24,21 +20,6 @@ if TYPE_CHECKING:
 
 
 class WorkflowListInstancesResponseMeta(ModelNormal):
-    @cached_property
-    def additional_properties_type(_):
-        return (
-            bool,
-            date,
-            datetime,
-            dict,
-            float,
-            int,
-            list,
-            str,
-            UUID,
-            none_type,
-        )
-
     @cached_property
     def openapi_types(_):
         from datadog_api_client.v2.model.workflow_list_instances_response_meta_page import (

--- a/src/datadog_api_client/v2/model/workflow_list_instances_response_meta_page.py
+++ b/src/datadog_api_client/v2/model/workflow_list_instances_response_meta_page.py
@@ -8,31 +8,12 @@ from typing import Union
 from datadog_api_client.model_utils import (
     ModelNormal,
     cached_property,
-    date,
-    datetime,
-    none_type,
     unset,
     UnsetType,
-    UUID,
 )
 
 
 class WorkflowListInstancesResponseMetaPage(ModelNormal):
-    @cached_property
-    def additional_properties_type(_):
-        return (
-            bool,
-            date,
-            datetime,
-            dict,
-            float,
-            int,
-            list,
-            str,
-            UUID,
-            none_type,
-        )
-
     @cached_property
     def openapi_types(_):
         return {

--- a/src/datadog_api_client/v2/model/worklflow_get_instance_response.py
+++ b/src/datadog_api_client/v2/model/worklflow_get_instance_response.py
@@ -8,12 +8,8 @@ from typing import Union, TYPE_CHECKING
 from datadog_api_client.model_utils import (
     ModelNormal,
     cached_property,
-    date,
-    datetime,
-    none_type,
     unset,
     UnsetType,
-    UUID,
 )
 
 
@@ -22,21 +18,6 @@ if TYPE_CHECKING:
 
 
 class WorklflowGetInstanceResponse(ModelNormal):
-    @cached_property
-    def additional_properties_type(_):
-        return (
-            bool,
-            date,
-            datetime,
-            dict,
-            float,
-            int,
-            list,
-            str,
-            UUID,
-            none_type,
-        )
-
     @cached_property
     def openapi_types(_):
         from datadog_api_client.v2.model.worklflow_get_instance_response_data import WorklflowGetInstanceResponseData

--- a/src/datadog_api_client/v2/model/worklflow_get_instance_response_data.py
+++ b/src/datadog_api_client/v2/model/worklflow_get_instance_response_data.py
@@ -8,12 +8,8 @@ from typing import Union, TYPE_CHECKING
 from datadog_api_client.model_utils import (
     ModelNormal,
     cached_property,
-    date,
-    datetime,
-    none_type,
     unset,
     UnsetType,
-    UUID,
 )
 
 
@@ -24,21 +20,6 @@ if TYPE_CHECKING:
 
 
 class WorklflowGetInstanceResponseData(ModelNormal):
-    @cached_property
-    def additional_properties_type(_):
-        return (
-            bool,
-            date,
-            datetime,
-            dict,
-            float,
-            int,
-            list,
-            str,
-            UUID,
-            none_type,
-        )
-
     @cached_property
     def openapi_types(_):
         from datadog_api_client.v2.model.worklflow_get_instance_response_data_attributes import (

--- a/src/datadog_api_client/v2/model/worklflow_get_instance_response_data_attributes.py
+++ b/src/datadog_api_client/v2/model/worklflow_get_instance_response_data_attributes.py
@@ -8,31 +8,12 @@ from typing import Union
 from datadog_api_client.model_utils import (
     ModelNormal,
     cached_property,
-    date,
-    datetime,
-    none_type,
     unset,
     UnsetType,
-    UUID,
 )
 
 
 class WorklflowGetInstanceResponseDataAttributes(ModelNormal):
-    @cached_property
-    def additional_properties_type(_):
-        return (
-            bool,
-            date,
-            datetime,
-            dict,
-            float,
-            int,
-            list,
-            str,
-            UUID,
-            none_type,
-        )
-
     @cached_property
     def openapi_types(_):
         return {


### PR DESCRIPTION
Currently, there is some conflicting behavior across multiple code paths. Some code path assumes additionalProperties is false by default where others, it is enabled. For example see: 

https://github.com/DataDog/datadog-api-client-python/blob/master/.generator/src/generator/templates/model_utils.j2#L132
and 
https://github.com/DataDog/datadog-api-client-python/blob/master/.generator/src/generator/templates/model_utils.j2#L400

To make sure behavior is uniform, lets enabled additionalProperties by default.