### PR TITLE
Handle nested oneOfs during serialization

### DIFF
--- a/.generator/src/generator/templates/model_utils.j2
+++ b/.generator/src/generator/templates/model_utils.j2
@@ -1373,8 +1373,11 @@ def model_to_dict(model_instance, serialize=True):
     result = {}
 
     model_instances = [model_instance]
-    if model_instance._composed_schemas:
-        model_instances.extend(model_instance._composed_instances)
+    model = model_instance
+    while model._composed_schemas:
+        model_instances.extend(model._composed_instances)
+        model = model.get_oneof_instance()
+
     seen_json_attribute_names = set()
     used_fallback_python_attribute_names = set()
     py_to_json_map = {}

--- a/src/datadog_api_client/model_utils.py
+++ b/src/datadog_api_client/model_utils.py
@@ -1387,8 +1387,11 @@ def model_to_dict(model_instance, serialize=True):
     result = {}
 
     model_instances = [model_instance]
-    if model_instance._composed_schemas:
-        model_instances.extend(model_instance._composed_instances)
+    model = model_instance
+    while model._composed_schemas:
+        model_instances.extend(model._composed_instances)
+        model = model.get_oneof_instance()
+
     seen_json_attribute_names = set()
     used_fallback_python_attribute_names = set()
     py_to_json_map = {}


### PR DESCRIPTION
Handle nested oneOf models during serialization.

Fixes: https://github.com/DataDog/datadog-api-client-python/pull/2125