### PR TITLE
Stop strings in arbitrary type fields from automatically converting to UUID

### DIFF
--- a/.generator/src/generator/templates/model_utils.j2
+++ b/.generator/src/generator/templates/model_utils.j2
@@ -572,7 +572,7 @@ COERCION_INDEX_BY_TYPE = {
 UPCONVERSION_TYPE_PAIRS = (
     (str, datetime),
     (str, date),
-    (str, UUID),
+    # (str, UUID),
     (int, float),  # A float may be serialized as an integer, e.g. '3' is a valid serialized float.
     (list, ModelComposed),
     (dict, ModelComposed),

--- a/.generator/src/generator/templates/model_utils.j2
+++ b/.generator/src/generator/templates/model_utils.j2
@@ -572,7 +572,7 @@ COERCION_INDEX_BY_TYPE = {
 UPCONVERSION_TYPE_PAIRS = (
     (str, datetime),
     (str, date),
-    # (str, UUID),
+    # (str, UUID), # Strings shouldn't always be converted to UUIDs, only when the format is a UUID explicitly.
     (int, float),  # A float may be serialized as an integer, e.g. '3' is a valid serialized float.
     (list, ModelComposed),
     (dict, ModelComposed),

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     entry: bash -c "SPHINX_APIDOC_OPTIONS=members,show-inheritance sphinx-apidoc --output-dir docs --force --no-toc --templatedir docs/_templates src/datadog_api_client *apis *models *version.py"
     pass_filenames: false
     additional_dependencies:
-      - Sphinx
+      - Sphinx==7.4.0
   - id: generator
     name: generator
     language: python

--- a/src/datadog_api_client/model_utils.py
+++ b/src/datadog_api_client/model_utils.py
@@ -586,7 +586,7 @@ COERCION_INDEX_BY_TYPE = {
 UPCONVERSION_TYPE_PAIRS = (
     (str, datetime),
     (str, date),
-    # (str, UUID),
+    # (str, UUID), # Strings shouldn't always be converted to UUIDs, only when the format is a UUID explicitly.
     (int, float),  # A float may be serialized as an integer, e.g. '3' is a valid serialized float.
     (list, ModelComposed),
     (dict, ModelComposed),

--- a/src/datadog_api_client/model_utils.py
+++ b/src/datadog_api_client/model_utils.py
@@ -586,7 +586,7 @@ COERCION_INDEX_BY_TYPE = {
 UPCONVERSION_TYPE_PAIRS = (
     (str, datetime),
     (str, date),
-    (str, UUID),
+    # (str, UUID),
     (int, float),  # A float may be serialized as an integer, e.g. '3' is a valid serialized float.
     (list, ModelComposed),
     (dict, ModelComposed),


### PR DESCRIPTION
Strings should only be deserialized into UUIDs if the type is explicitly UUID - otherwise, random hashes that aren't uuids can be converted unintentionally. The only time both str and UUID is valid for a type is for arbitrary type fields, so this only applies to arbitrary objects and additionalProperties.

Also pins the Sphinx version in pre-commit to stabilize the `.rst` doc files. (7.4.0 has a slightly different format to ^8.0.0)