### PR TITLE
Change ubuntu image 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,11 +78,15 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.12"]
-        platform: [ubuntu-latest, macos-latest] # windows-latest
+        platform: [ubuntu-latest, macos-latest, ubuntu-22.04] # windows-latest
         # test only latest version on macos and windows
         exclude:
           - platform: macos-latest
             python-version: "3.7"
+          - platform: ubuntu-latest
+            python-version: "3.7"
+          - platform: ubuntu-22.04
+            python-version: "3.12"
           # TODO enable once dd-trace-py is updated
           # - platform: windows-latest
           #  python-version: 3.7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.12"]
-        platform: [ubuntu-latest, macos-latest, ubuntu-22.04] # windows-latest
+        platform: [ubuntu-22.04, ubuntu-latest, macos-latest] # windows-latest
         # test only latest version on macos and windows
         exclude:
           - platform: macos-latest


### PR DESCRIPTION
Setup python was failing due to `ubuntu-latest` not supporting Python 3.7 (https://github.com/actions/setup-python/issues/962). Since we still support Python 3.7, we can run tests on `ubuntu-22.04`

This was tested in https://github.com/DataDog/datadog-api-client-python/compare/datadog-api-spec/test/vgranados/K9VULN-1347-vm-api and fixed this failing action: https://github.com/DataDog/datadog-api-client-python/actions/runs/12355542690/job/34479407275?pr=2324