### PR TITLE
Update link to docs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ with ApiClient(configuration) as api_client:
 
 ## Documentation for API Endpoints and Models
 
-Documentation for API endpoints and models are available on [readthedocs](https://datadog-api-client.readthedocs.io/).
+Documentation for API endpoints and models are available [here](https://datadoghq.dev/datadog-api-client-python/).
 
 ## Documentation for Authorization
 


### PR DESCRIPTION
The old location hasn't been built in a long time https://app.readthedocs.org/projects/datadog-api-client/builds/