### PR TITLE
fix flaky tests due to header casing

### DIFF
--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -2,6 +2,7 @@ import os
 import time
 
 import pytest
+from aiosonic import HttpHeaders
 
 from datadog_api_client.api_client import AsyncApiClient
 from datadog_api_client.configuration import Configuration
@@ -21,7 +22,9 @@ async def test_error():
         error = str(e.value)
         assert "(403)" in error
         assert "Reason: Forbidden" in error
-        assert e.value.headers["Content-Type"] == "application/json"
+        # cast headers to HttpHeaders to make them case insensitive
+        headers = HttpHeaders(e.value.headers)
+        assert headers["content-type"] == "application/json"
         assert e.value.body["errors"] == ["Forbidden"]
 
 
@@ -41,7 +44,8 @@ async def test_basic():
         api_instance = dashboards_api.DashboardsApi(api_client)
         _, code, headers = await api_instance.list_dashboards()
         assert code == 200
-        assert headers["Content-Type"] == "application/json"
+        headers = HttpHeaders(headers)
+        assert headers["content-type"] == "application/json"
 
 
 @pytest.mark.asyncio

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+from aiosonic import HttpHeaders
 
 from datadog_api_client.api_client import ThreadedApiClient
 from datadog_api_client.configuration import Configuration
@@ -23,4 +24,6 @@ def test_basic():
         thread = api_instance.list_dashboards()
         _, code, headers = thread.get()
         assert code == 200
-        assert headers["Content-Type"] == "application/json"
+        # cast headers to HttpHeaders to make them case insensitive
+        headers = HttpHeaders(headers)
+        assert headers["content-type"] == "application/json"


### PR DESCRIPTION
`test_async` has been flaking since headers are case insensitive — `test_thread` does the same type of check so we should make the update in that test as well