### PR TITLE
Do not cancel concurrent CI matrix jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,7 @@ jobs:
 
   test:
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.8", "3.12"]
         platform: [ubuntu-22.04, ubuntu-latest, macos-latest] # windows-latest


### PR DESCRIPTION
Failing fast makes it impossible to determine if the issue is specific to one job in the matrix or not, as we would never get the results from the others to compare.