### PR TITLE
add fake app key

### DIFF
--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -14,6 +14,7 @@ from datadog_api_client.v1.api import dashboards_api, metrics_api
 async def test_error():
     configuration = Configuration()
     configuration.api_key["apiKeyAuth"] = "00000000000000000000000000000000"
+    configuration.api_key["appKeyAuth"] = "00000000000000000000000000000000"
 
     async with AsyncApiClient(configuration) as api_client:
         api_instance = metrics_api.MetricsApi(api_client)


### PR DESCRIPTION
If no APP key is passed at all, Metrics API has started to return a 401 instead of a 403