### PR TITLE
Bump maximum integration_type value to 15

### DIFF
--- a/src/datadog_api_client/v2/model/incident_integration_metadata_attributes.py
+++ b/src/datadog_api_client/v2/model/incident_integration_metadata_attributes.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 class IncidentIntegrationMetadataAttributes(ModelNormal):
     validations = {
         "integration_type": {
-            "inclusive_maximum": 9,
+            "inclusive_maximum": 15,
         },
         "status": {
             "inclusive_maximum": 5,


### PR DESCRIPTION
<!--
** Requirements for Contributing to this repository **

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->

### What does this PR do?

Fixes API client exceptions when the list of incident integrations includes `integration_type` `15`.

### Current Behavior

We're getting the following exception when making calls to `https://api.datadoghq.com/api/v2/incidents/{uuid}/relationships/integrations` via this library:

> Invalid value for `integration_type`, must be a value less than or equal to `9`

<details>
<summary>Stack Trace</summary>

```
Traceback (most recent call last):

  File "/venv/lib/python3.11/site-packages/datadog_api_client/v2/api/incidents_api.py", line 986, in list_incident_integrations
    return self._list_incident_integrations_endpoint.call_with_http_info(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/venv/lib/python3.11/site-packages/datadog_api_client/api_client.py", line 785, in call_with_http_info
    return self.api_client.call_api(
           ^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/venv/lib/python3.11/site-packages/datadog_api_client/api_client.py", line 290, in call_api
    return self._call_api(
           ^^^^^^^^^^^^^^^

  File "/venv/lib/python3.11/site-packages/datadog_api_client/api_client.py", line 129, in _call_api
    return_data = self.deserialize(response_data, response_type, check_type)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/venv/lib/python3.11/site-packages/datadog_api_client/api_client.py", line 183, in deserialize
    deserialized_data = validate_and_convert_types(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/venv/lib/python3.11/site-packages/datadog_api_client/model_utils.py", line 1301, in validate_and_convert_types
    return attempt_convert_item(
           ^^^^^^^^^^^^^^^^^^^^^

  File "/venv/lib/python3.11/site-packages/datadog_api_client/model_utils.py", line 1208, in attempt_convert_item
    raise conversion_exc

  File "/venv/lib/python3.11/site-packages/datadog_api_client/model_utils.py", line 1200, in attempt_convert_item
    return deserialize_model(
           ^^^^^^^^^^^^^^^^^^

  File "/venv/lib/python3.11/site-packages/datadog_api_client/model_utils.py", line 1119, in deserialize_model
    return model_class(**kw_args)
           ^^^^^^^^^^^^^^^^^^^^^^

  File "/venv/lib/python3.11/site-packages/datadog_api_client/v2/model/incident_integration_metadata_list_response.py", line 79, in __init__
    self_.data = data
    ^^^^^^^^^^

  File "/venv/lib/python3.11/site-packages/datadog_api_client/model_utils.py", line 183, in __setattr__
    self[attr] = value
    ~~~~^^^^^^

  File "/venv/lib/python3.11/site-packages/datadog_api_client/model_utils.py", line 360, in __setitem__
    self.set_attribute(name, value)

  File "/venv/lib/python3.11/site-packages/datadog_api_client/model_utils.py", line 155, in set_attribute
    value = validate_and_convert_types(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/venv/lib/python3.11/site-packages/datadog_api_client/model_utils.py", line 1345, in validate_and_convert_types
    validate_and_convert_types(

  File "/venv/lib/python3.11/site-packages/datadog_api_client/model_utils.py", line 1301, in validate_and_convert_types
    return attempt_convert_item(
           ^^^^^^^^^^^^^^^^^^^^^

  File "/venv/lib/python3.11/site-packages/datadog_api_client/model_utils.py", line 1208, in attempt_convert_item
    raise conversion_exc

  File "/venv/lib/python3.11/site-packages/datadog_api_client/model_utils.py", line 1200, in attempt_convert_item
    return deserialize_model(
           ^^^^^^^^^^^^^^^^^^

  File "/venv/lib/python3.11/site-packages/datadog_api_client/model_utils.py", line 1119, in deserialize_model
    return model_class(**kw_args)
           ^^^^^^^^^^^^^^^^^^^^^^

  File "/venv/lib/python3.11/site-packages/datadog_api_client/v2/model/incident_integration_metadata_response_data.py", line 74, in __init__
    super().__init__(kwargs)

  File "/venv/lib/python3.11/site-packages/datadog_api_client/model_utils.py", line 409, in __init__
    setattr(self, var_name, var_value)

  File "/venv/lib/python3.11/site-packages/datadog_api_client/model_utils.py", line 183, in __setattr__
    self[attr] = value
    ~~~~^^^^^^

  File "/venv/lib/python3.11/site-packages/datadog_api_client/model_utils.py", line 360, in __setitem__
    self.set_attribute(name, value)

  File "/venv/lib/python3.11/site-packages/datadog_api_client/model_utils.py", line 155, in set_attribute
    value = validate_and_convert_types(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/venv/lib/python3.11/site-packages/datadog_api_client/model_utils.py", line 1301, in validate_and_convert_types
    return attempt_convert_item(
           ^^^^^^^^^^^^^^^^^^^^^

  File "/venv/lib/python3.11/site-packages/datadog_api_client/model_utils.py", line 1208, in attempt_convert_item
    raise conversion_exc

  File "/venv/lib/python3.11/site-packages/datadog_api_client/model_utils.py", line 1200, in attempt_convert_item
    return deserialize_model(
           ^^^^^^^^^^^^^^^^^^

  File "/venv/lib/python3.11/site-packages/datadog_api_client/model_utils.py", line 1119, in deserialize_model
    return model_class(**kw_args)
           ^^^^^^^^^^^^^^^^^^^^^^

  File "/venv/lib/python3.11/site-packages/datadog_api_client/v2/model/incident_integration_metadata_attributes.py", line 111, in __init__
    self_.integration_type = integration_type
    ^^^^^^^^^^^^^^^^^^^^^^

  File "/venv/lib/python3.11/site-packages/datadog_api_client/model_utils.py", line 183, in __setattr__
    self[attr] = value
    ~~~~^^^^^^

  File "/venv/lib/python3.11/site-packages/datadog_api_client/model_utils.py", line 360, in __setitem__
    self.set_attribute(name, value)

  File "/venv/lib/python3.11/site-packages/datadog_api_client/model_utils.py", line 168, in set_attribute
    check_validations(self.validations[name], name, value, self._configuration)

  File "/venv/lib/python3.11/site-packages/datadog_api_client/model_utils.py", line 823, in check_validations
    raise ApiValueError(

datadog_api_client.exceptions.ApiValueError: Invalid value for `integration_type`, must be a value less than or equal to `9`
```

</details>

We captured the API response and saw a value of `15` coming through (which I think is related to On-Call?)

<details>
<summary>Partial Response (heavily sanitized)</summary>

```json5
{
  "data": [
    {
      "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
      "type": "incident_integrations",
      "attributes": {
        // ...
        "integration_type": 1,
        // ...
      },
      // ...
    },
    {
      "id": "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy",
      "type": "incident_integrations",
      "attributes": {
        // ...
        "integration_type": 8,
        // ...
      },
      // ...
    },
    {
      "id": "zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz",
      "type": "incident_integrations",
      "attributes": {
        // ...
        "integration_type": 4,
        // ...
      },
      // ...
    },
    {
      "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
      "type": "incident_integrations",
      "attributes": {
        "created": "2025-07-02T11:50:50.283211Z",
        "created_by_uuid": "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy",
        "incident_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
        "integration_type": 15, // <---------------------------------------- the problematic value
        "last_modified_by_uuid": "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy",
        "metadata": {
          "pages": [
            {
              "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
              "key": "5678",
              "team_id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
              "page_target": {
                "type": "team_uuid",
                "identifier": "cccccccc-cccc-cccc-cccc-cccccccccccc"
              }
            }
          ]
        },
        "modified": "2025-07-02T11:50:50.283211Z",
        "status": 2
      },
      "relationships": {
        "created_by_user": {
          "data": {
            "id": "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy",
            "type": "users"
          }
        },
        "last_modified_by_user": {
          "data": {
            "id": "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy",
            "type": "users"
          }
        }
      }
    }
  ],
  "meta": {
    "pagination": {
      "offset": 0,
      "next_offset": 25,
      "size": 4
    }
  }
}
```

</details>

### Expected Behavior

The API client should pass along this information to my application instead of raising an exception.

### Additional Notes

Instead of bumping this value each time a new integration is added, perhaps the validation should be removed? Otherwise more changes like this will be needed in the future.

Also, my stack trace is from version 2.32.0, but the validation rule seems to exist in the latest version, so I'm assuming the issue is still present in the latest version.

### Review checklist

Please check relevant items below:

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [x] This PR does not rely on API client schema changes.
  - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.
