### PR TITLE
Fix oneOf handling for lists of primitives in model_utils

### DIFF
--- a/.generator/src/generator/templates/model_utils.j2
+++ b/.generator/src/generator/templates/model_utils.j2
@@ -75,6 +75,9 @@ def composed_model_input_classes(cls):
     This function returns a list of the possible models that can be accepted as
     inputs.
     """
+    # Handle list types (e.g., [str], [float])
+    if isinstance(cls, list):
+        return [cls]
     if issubclass(cls, ModelSimple) or cls in PRIMITIVE_TYPES:
         return [cls]
     elif issubclass(cls, ModelNormal):
@@ -1557,17 +1560,44 @@ def get_oneof_instance(cls, model_kwargs, constant_kwargs, model_arg=None):
                         # Empty data
                         oneof_instances.append(list_oneof_instance)
                         continue
-                    for arg in model_arg:
-                        if constant_kwargs.get("_spec_property_naming"):
-                            oneof_instance = oneof_class(
-                                **change_keys_js_to_python(arg, oneof_class), **constant_kwargs
+
+                    # Check if inner type is primitive - follows same pattern as complex objects:
+                    # https://github.com/DataDog/datadog-api-client-python/blob/008536d34760ce096e118edc54df613d82194529/.generator/src/generator/templates/model_utils.j2#L1590-L1599
+                    if oneof_class in PRIMITIVE_TYPES:
+                        # Handle list of primitives (e.g., [str], [float])
+                        for arg in model_arg:
+                            oneof_instance = validate_and_convert_types(
+                                arg,
+                                (oneof_class,),
+                                constant_kwargs.get("_path_to_item", ()),
+                                constant_kwargs.get("_spec_property_naming", False),
+                                constant_kwargs.get("_check_type", True),
+                                configuration=constant_kwargs.get("_configuration"),
                             )
-                        else:
-                            oneof_instance = oneof_class(**arg, **constant_kwargs)
-                        if not oneof_instance._unparsed:
                             list_oneof_instance.append(oneof_instance)
-                    if list_oneof_instance:
-                        oneof_instances.append(list_oneof_instance)
+                        if list_oneof_instance:
+                            oneof_instances.append(list_oneof_instance)
+                    elif inspect.isclass(oneof_class) and issubclass(oneof_class, ModelSimple):
+                        # Handle list of ModelSimple
+                        for arg in model_arg:
+                            oneof_instance = oneof_class(arg, **constant_kwargs)
+                            if not oneof_instance._unparsed:
+                                list_oneof_instance.append(oneof_instance)
+                        if list_oneof_instance:
+                            oneof_instances.append(list_oneof_instance)
+                    else:
+                        # Handle list of complex objects (ModelNormal, ModelComposed)
+                        for arg in model_arg:
+                            if constant_kwargs.get("_spec_property_naming"):
+                                oneof_instance = oneof_class(
+                                    **change_keys_js_to_python(arg, oneof_class), **constant_kwargs
+                                )
+                            else:
+                                oneof_instance = oneof_class(**arg, **constant_kwargs)
+                            if not oneof_instance._unparsed:
+                                list_oneof_instance.append(oneof_instance)
+                        if list_oneof_instance:
+                            oneof_instances.append(list_oneof_instance)
                 elif issubclass(oneof_class, ModelSimple):
                     if model_arg is not None:
                         oneof_instance = oneof_class(model_arg, **constant_kwargs)

--- a/src/datadog_api_client/model_utils.py
+++ b/src/datadog_api_client/model_utils.py
@@ -77,6 +77,9 @@ def composed_model_input_classes(cls):
     This function returns a list of the possible models that can be accepted as
     inputs.
     """
+    # Handle list types (e.g., [str], [float])
+    if isinstance(cls, list):
+        return [cls]
     if issubclass(cls, ModelSimple) or cls in PRIMITIVE_TYPES:
         return [cls]
     elif issubclass(cls, ModelNormal):
@@ -1571,17 +1574,44 @@ def get_oneof_instance(cls, model_kwargs, constant_kwargs, model_arg=None):
                         # Empty data
                         oneof_instances.append(list_oneof_instance)
                         continue
-                    for arg in model_arg:
-                        if constant_kwargs.get("_spec_property_naming"):
-                            oneof_instance = oneof_class(
-                                **change_keys_js_to_python(arg, oneof_class), **constant_kwargs
+
+                    # Check if inner type is primitive - follows same pattern as complex objects:
+                    # https://github.com/DataDog/datadog-api-client-python/blob/008536d34760ce096e118edc54df613d82194529/.generator/src/generator/templates/model_utils.j2#L1590-L1599
+                    if oneof_class in PRIMITIVE_TYPES:
+                        # Handle list of primitives (e.g., [str], [float])
+                        for arg in model_arg:
+                            oneof_instance = validate_and_convert_types(
+                                arg,
+                                (oneof_class,),
+                                constant_kwargs.get("_path_to_item", ()),
+                                constant_kwargs.get("_spec_property_naming", False),
+                                constant_kwargs.get("_check_type", True),
+                                configuration=constant_kwargs.get("_configuration"),
                             )
-                        else:
-                            oneof_instance = oneof_class(**arg, **constant_kwargs)
-                        if not oneof_instance._unparsed:
                             list_oneof_instance.append(oneof_instance)
-                    if list_oneof_instance:
-                        oneof_instances.append(list_oneof_instance)
+                        if list_oneof_instance:
+                            oneof_instances.append(list_oneof_instance)
+                    elif inspect.isclass(oneof_class) and issubclass(oneof_class, ModelSimple):
+                        # Handle list of ModelSimple
+                        for arg in model_arg:
+                            oneof_instance = oneof_class(arg, **constant_kwargs)
+                            if not oneof_instance._unparsed:
+                                list_oneof_instance.append(oneof_instance)
+                        if list_oneof_instance:
+                            oneof_instances.append(list_oneof_instance)
+                    else:
+                        # Handle list of complex objects (ModelNormal, ModelComposed)
+                        for arg in model_arg:
+                            if constant_kwargs.get("_spec_property_naming"):
+                                oneof_instance = oneof_class(
+                                    **change_keys_js_to_python(arg, oneof_class), **constant_kwargs
+                                )
+                            else:
+                                oneof_instance = oneof_class(**arg, **constant_kwargs)
+                            if not oneof_instance._unparsed:
+                                list_oneof_instance.append(oneof_instance)
+                        if list_oneof_instance:
+                            oneof_instances.append(list_oneof_instance)
                 elif issubclass(oneof_class, ModelSimple):
                     if model_arg is not None:
                         oneof_instance = oneof_class(model_arg, **constant_kwargs)


### PR DESCRIPTION
## Context

PR https://github.com/DataDog/datadog-api-spec/pull/4191 introduced a new model `CustomAttributeValuesUnion` with a oneOf schema containing primitive list types:

```python
oneOf: [str, [str], float, [float]]
```

This caused test failures in the generated Python client (https://github.com/DataDog/datadog-api-client-python/pull/2759):
- CI Run: https://github.com/DataDog/datadog-api-client-python/actions/runs/18286712780/job/52063527051
- Failing test: `test_update_case_custom_attribute_returns_not_found_response`

The issue was that the generator tried to instantiate primitive types using dict unpacking (`str(**arg, **kwargs)`), which fails with a `TypeError`.

This is because of two bugs in the `model_utils.j2` template:

1. **`get_oneof_instance` function**: When handling list types in oneOf schemas, the code didn't distinguish between:
   - Lists of primitives (e.g., `[str]`, `[float]`)
   - Lists of ModelSimple objects
   - Lists of complex objects (ModelNormal, ModelComposed)
  
   That's because checking `cls in PRIMITIVE_TYPES` doesn't catch a list of string for example.

   It treated all lists the same way, using dict unpacking which only works for complex objects.

2. **`composed_model_input_classes` function**: Called `issubclass([str], ModelSimple)` which fails with `TypeError: issubclass() arg 1 must be a class` when the oneOf schema contains list types like `[str]`.

## Changes

Updated `.generator/src/generator/templates/model_utils.j2` with two fixes:

### 1. Type Guard in `composed_model_input_classes` (lines 73-92)

Added a guard to handle list types before calling `issubclass`:

```python
if isinstance(cls, list):
    return [cls]
```

This prevents `TypeError: issubclass() arg 1 must be a class` when encountering list types like `[str]` or `[float]` in oneOf schemas.

### 2. Three-Way List Handling in `get_oneof_instance` (lines 1558-1602)

Distinguished between three types of list contents:

- **Lists of primitives** (`[str]`, `[float]`): Use `validate_and_convert_types` to properly handle primitive values
- **Lists of ModelSimple**: Use single-arg constructor `ModelSimple(arg)`
- **Lists of complex objects**: Use dict unpacking (existing behavior preserved)


## Tests

I cherry-picked the changes from this PR onto https://github.com/DataDog/datadog-api-client-python/pull/2759 and ran the tests (I unskipped the problematic test before)

## Related Work

Similar issues were fixed in the Java client:
- https://github.com/DataDog/datadog-api-client-java/pull/3177
- https://github.com/DataDog/datadog-api-client-java/pull/3180
