### PR TITLE
Allow empty descriptions.

### DIFF
--- a/.generator/src/generator/cli.py
+++ b/.generator/src/generator/cli.py
@@ -125,7 +125,7 @@ def cli(specs, output):
             api_path = package / "api" / filename
             api_path.parent.mkdir(parents=True, exist_ok=True)
             with api_path.open("w") as fp:
-                fp.write(api_j2.render(name=name, operations=operations, description=tags_by_name[name]["description"]))
+                fp.write(api_j2.render(name=name, operations=operations, description=tags_by_name[name].get("description")))
 
         api_init_path = package / "api" / "__init__.py"
         with api_init_path.open("w") as fp:

--- a/.generator/src/generator/formatter.py
+++ b/.generator/src/generator/formatter.py
@@ -167,7 +167,7 @@ class CustomRenderer(m2r2.RestRenderer):
 
 def docstring(text):
     return (
-        m2r2.convert(text.replace("\\n", "\\\\n"), renderer=CustomRenderer())[1:-1]
+        m2r2.convert((text or "").replace("\\n", "\\\\n"), renderer=CustomRenderer())[1:-1]
         .replace("\\ ", " ")
         .replace("\\`", "\\\\`")
         .replace("\n\n\n", "\n\n")

--- a/.generator/src/generator/templates/model_enum.j2
+++ b/.generator/src/generator/templates/model_enum.j2
@@ -3,7 +3,9 @@ from typing import ClassVar
 
 class {{ name }}(ModelSimple):
     """
+{%- if "description" in model %}
     {{ model.description|indent(8) }}
+{%- endif %}
 
     :param value: {%- if default != None %} If omitted defaults to {{ default|format_value }}.{%- endif %} Must be one of [{%- for value in model.enum %}{{ value|format_value }}{% if not loop.last %}, {% endif %}{%- endfor %}].
     :type value: {{ get_enum_type(model) }}

--- a/.generator/src/generator/templates/model_generic.j2
+++ b/.generator/src/generator/templates/model_generic.j2
@@ -127,7 +127,7 @@ class {{ name }}(ModelNormal):
 {%- endif %}
 {%- for attr, definition in model.get("properties", {}).items() %}
 {# keep new line #}
-        :param {{ attr|attribute_name }}: {{ definition.description|docstring|indent(12) }}{% if definition.deprecated %} **Deprecated**.{% endif %}
+        :param {{ attr|attribute_name }}: {% if "description" in definition %}{{ definition.description|docstring|indent(12) }}{% if definition.deprecated %} **Deprecated**.{% endif %}{% endif %}
         :type {{ attr|attribute_name }}: {{ get_type_for_attribute(model, attr, current_name=name) }}{% if definition.nullable %}, none_type{% endif %}{% if attr not in model.get("required", []) %}, optional{% endif %}
 {%- endfor %}
         """

--- a/.generator/src/generator/templates/model_oneof.j2
+++ b/.generator/src/generator/templates/model_oneof.j2
@@ -8,10 +8,12 @@ class {{ name }}(ModelComposed):
 
     def __init__(self, **kwargs):
         """
+{%- if "description" in model %}
         {{ model.description|docstring|indent(8) }}
+{%- endif %}
 {%- for attr, definition, schema in get_oneof_parameters(model) %}
 {# keep new line #}
-        :param {{ attr|attribute_name }}: {{ definition.description|indent(12) }}
+        :param {{ attr|attribute_name }}: {% if "description" in definition %}{{ definition.description|indent(12) }}{% endif %}
         :type {{ attr|attribute_name }}: {{ get_type_for_attribute(schema, attr, current_name=name) }}{% if definition.nullable %}, none_type{% endif %}{% if attr not in schema.get("required", []) %}, optional{% endif %}
 {%- endfor %}
         """

--- a/.generator/src/generator/templates/model_simple.j2
+++ b/.generator/src/generator/templates/model_simple.j2
@@ -2,7 +2,9 @@
 
 class {{ name }}(ModelSimple):
     """
+{%- if "description" in model %}
     {{ model.description|docstring|indent(8) }}
+{%- endif %}
 
 {# empty line #}
 {%- if "default" in model and model.default != None %}


### PR DESCRIPTION
Generates code even if things have missing `description`s. Tested with
```
yq -i 'del(.. | .description?)' .generator/schemas/v2/openapi.yaml
pre-commit run --all-files --hook-stage=manual generator
```