### PR TITLE
Fix consecutive-acronym handling in generated examples and apis/__init__.py

### DIFF
--- a/.generator/conftest.py
+++ b/.generator/conftest.py
@@ -352,9 +352,9 @@ def undo_operations():
 @given(parsers.parse('an instance of "{name}" API'))
 def api(context, api_version, specs, name):
     """Return an API instance."""
-    assert name in {tag["name"].replace(" ", "") for tag in specs[api_version]["tags"]}
+    raw_tag = next(t["name"] for t in specs[api_version]["tags"] if t["name"].replace(" ", "") == name)
     sanitized_name = name.replace("-", "")
-    context["api_instance"] = {"name": sanitized_name}
+    context["api_instance"] = {"name": sanitized_name, "raw_tag": raw_tag}
 
 
 @given(parsers.parse('operation "{name}" enabled'))

--- a/.generator/src/generator/templates/apis.j2
+++ b/.generator/src/generator/templates/apis.j2
@@ -1,6 +1,6 @@
 {%- for api in apis %}
 {%- set classname = api|class_name %}
-from {{ package }}.{{ version }}.api.{{ api|safe_snake_case }} import {{ classname }}
+from {{ package }}.{{ version }}.api.{{ api|safe_snake_case }}_api import {{ classname }}
 {%- endfor %}
 
 

--- a/.generator/src/generator/templates/apis.j2
+++ b/.generator/src/generator/templates/apis.j2
@@ -1,6 +1,6 @@
 {%- for api in apis %}
 {%- set classname = api|class_name %}
-from {{ package }}.{{ version }}.api.{{ classname|safe_snake_case }} import {{ classname }}
+from {{ package }}.{{ version }}.api.{{ api|safe_snake_case }} import {{ classname }}
 {%- endfor %}
 
 

--- a/.generator/src/generator/templates/example.j2
+++ b/.generator/src/generator/templates/example.j2
@@ -14,7 +14,7 @@
 from {{ package }} import {{ values|sort|join(', ') }}
 {%- endfor %}
 from datadog_api_client import ApiClient, Configuration
-from datadog_api_client.{{ version }}.api.{{ context.api_instance.name|safe_snake_case }}_api import {{ context.api_instance.name }}Api
+from datadog_api_client.{{ version }}.api.{{ context.api_instance.raw_tag|safe_snake_case }}_api import {{ context.api_instance.name }}Api
 {%- for package in imports|sort %}
 from {{ package }} import {{ imports[package]|sort|join(', ') }}
 {%- endfor %}


### PR DESCRIPTION
## Summary

Fixes broken imports in generated examples and `apis/__init__.py` when an OpenAPI tag contains consecutive acronyms (e.g. `Bits AI SRE`).

The library files themselves (`bits_ai_sre_api.py`) generate correctly because `cli.py` snake_cases the raw tag. But two places worked from a spaceless PascalCase form (`BitsAISRE` / `BitsAISREApi`) and re-snake_cased that, which produced `bits_aisre_api`.

Changes:
- `templates/apis.j2`: snake_case the raw tag (loop variable `api`) instead of the class name.
- `templates/example.j2`: import from `raw_tag|safe_snake_case` instead of `name|safe_snake_case`.
- `.generator/conftest.py`: stash the raw tag in `context["api_instance"]` so templates can use it.

Behavior is unchanged for any tag without consecutive acronyms.

## Test plan

- [x] Run `./generate.sh` locally with "Bits AI SRE" tag

## Links

- Spec PR (originating change): https://github.com/DataDog/datadog-api-spec/pull/5522
- Sibling: Rust — https://github.com/DataDog/datadog-api-client-rust/pull/1530
- Sibling: Java — https://github.com/DataDog/datadog-api-client-java/pull/3766