### PR TITLE
Fix ClientRetry.get_retry_after when X-Ratelimit-Reset appears twice

### DIFF
--- a/src/datadog_api_client/rest.py
+++ b/src/datadog_api_client/rest.py
@@ -36,11 +36,14 @@ class ClientRetry(urllib3.util.Retry):
         This method overrides the default "Retry-after" header and uses dd's X-Ratelimit-Reset header
         and gets the value of X-Ratelimit-Reset in seconds.
         """
-        retry_after = response.headers.get("X-Ratelimit-Reset")
-
-        if retry_after is None:
+        # The server may return the X-Ratelimit-Reset header more than once. urllib3's
+        # HTTPHeaderDict.get() concatenates repeated headers with ", " (per RFC 9110 §5.3),
+        # which yields values like "7, 7" that parse_retry_after cannot parse. Use
+        # getlist() to pick a single occurrence instead.
+        values = response.headers.getlist("X-Ratelimit-Reset")
+        if not values:
             return None
-        return self.parse_retry_after(retry_after)
+        return self.parse_retry_after(values[0])
 
     def is_retry(self, method, status_code, has_retry_after=False):
         if method not in self.DEFAULT_ALLOWED_METHODS:

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,10 +1,42 @@
 from unittest import mock
 import pytest
 import vcr
+from urllib3._collections import HTTPHeaderDict
 
 from datadog_api_client.api_client import ApiClient
 from datadog_api_client.configuration import Configuration
+from datadog_api_client.rest import ClientRetry
 from datadog_api_client.v2.api import logs_api
+
+
+class _FakeResponse:
+    def __init__(self, headers):
+        self.headers = HTTPHeaderDict()
+        for name, value in headers:
+            self.headers.add(name, value)
+
+
+def test_get_retry_after_single_header():
+    retry = ClientRetry(total=5, backoff_factor=2)
+    response = _FakeResponse([("X-Ratelimit-Reset", "7")])
+    assert retry.get_retry_after(response) == 7
+
+
+def test_get_retry_after_missing_header():
+    retry = ClientRetry(total=5, backoff_factor=2)
+    response = _FakeResponse([])
+    assert retry.get_retry_after(response) is None
+
+
+def test_get_retry_after_duplicate_header():
+    """The server sometimes returns X-Ratelimit-Reset twice; HTTPHeaderDict.get() would
+    then concatenate the values (e.g. "7, 7"), which parse_retry_after cannot handle."""
+    retry = ClientRetry(total=5, backoff_factor=2)
+    response = _FakeResponse([
+        ("X-Ratelimit-Reset", "7"),
+        ("X-Ratelimit-Reset", "7"),
+    ])
+    assert retry.get_retry_after(response) == 7
 
 
 @mock.patch("time.sleep", return_value=None)


### PR DESCRIPTION
### What does this PR do?

Fixes `ClientRetry.get_retry_after` in `src/datadog_api_client/rest.py` so it doesn't crash when the Datadog server returns the `X-Ratelimit-Reset` header more than once.

### Motivation

Datadog's server sometimes returns the `X-Ratelimit-Reset` header twice in a single response. `urllib3`'s `HTTPHeaderDict.get()` concatenates repeated headers with `", "` (per RFC 9110 §5.3), so the value becomes e.g. `"7, 7"`. `urllib3.util.Retry.parse_retry_after` only accepts a bare integer or an HTTP date, so it raises `InvalidHeader: Invalid Retry-After header: 7, 7`, the retry is abandoned, and the caller sees the original 429/5xx as a hard failure.

Observed at scale in a production sync job against the Software Catalog API (`upsert_catalog_entity`): roughly 1,800 upserts out of ~13,000 per run were failing with this error. After applying the fix in a vendored copy, the failures went away.

Related (different symptom, same area, open since 2024): #1923.

### Reproduction

Reproduced locally against `datadog-api-client-python==2.54.0` and `urllib3==2.6.3`:

```python
from datadog_api_client.rest import ClientRetry
from urllib3._collections import HTTPHeaderDict

class FakeResp:
    def __init__(self, headers):
        self.headers = HTTPHeaderDict()
        for k, v in headers:
            self.headers.add(k, v)

r = ClientRetry(total=5, backoff_factor=2)
# Simulates DD sending the header twice
print(r.get_retry_after(FakeResp([("X-Ratelimit-Reset", "7"), ("X-Ratelimit-Reset", "7")])))
# urllib3.exceptions.InvalidHeader: Invalid Retry-After header: 7, 7
```

### The fix

Use `HTTPHeaderDict.getlist()` to pick a single occurrence instead of relying on the concatenated `.get()` value:

```python
values = response.headers.getlist("X-Ratelimit-Reset")
if not values:
    return None
return self.parse_retry_after(values[0])
```

This preserves the normal-case behavior exactly (single header value) and handles the duplicate-header case gracefully. No new dependencies.

### Tests

Added three unit tests in `tests/test_retry.py` covering the single-header, missing-header, and duplicate-header cases for `ClientRetry.get_retry_after`. Used plain unit tests rather than the existing VCR cassette pattern because this is a pure header-parsing concern that doesn't need an HTTP layer.

### Notes

- `rest.py` appears to be hand-maintained (no generator banner, contains the custom `ClientRetry` class). If this file is in fact generated from a template I haven't located, happy to move the change there — please point me at the right spot.
- Opened as draft so maintainers can sanity-check the test placement before it lands.

### Review checklist

- [x] Added tests covering the changes
- [x] Verified fix resolves the real-world failure (production run against Software Catalog upsert, ~13k entities/run)
- [x] Preserves existing single-header behavior