### PR TITLE
Continue cursor pagination until results are empty

### DIFF
--- a/.generator/src/generator/templates/api_client.j2
+++ b/.generator/src/generator/templates/api_client.j2
@@ -350,9 +350,13 @@ class ApiClient:
                 host=host,
                 collection_formats=params["collection_format"],
             )
-            for item in get_attribute_from_path(response, pagination.get("results_path")):
+            results = get_attribute_from_path(response, pagination.get("results_path"))
+            for item in results:
                 yield item
-            if len(get_attribute_from_path(response, pagination.get("results_path"))) < pagination["limit_value"]:
+            if "cursor_param" in pagination:
+                if len(results) == 0:
+                    break
+            elif len(results) < pagination["limit_value"]:
                 break
 
             params = self._update_paginated_params(pagination, response)
@@ -651,9 +655,13 @@ class AsyncApiClient(ApiClient):
                 host=host,
                 collection_formats=params["collection_format"],
             )
-            for item in get_attribute_from_path(response, pagination.get("results_path")):
+            results = get_attribute_from_path(response, pagination.get("results_path"))
+            for item in results:
                 yield item
-            if len(get_attribute_from_path(response, pagination.get("results_path"))) < pagination["limit_value"]:
+            if "cursor_param" in pagination:
+                if len(results) == 0:
+                    break
+            elif len(results) < pagination["limit_value"]:
                 break
 
             params = self._update_paginated_params(pagination, response)

--- a/src/datadog_api_client/api_client.py
+++ b/src/datadog_api_client/api_client.py
@@ -357,9 +357,13 @@ class ApiClient:
                 host=host,
                 collection_formats=params["collection_format"],
             )
-            for item in get_attribute_from_path(response, pagination.get("results_path")):
+            results = get_attribute_from_path(response, pagination.get("results_path"))
+            for item in results:
                 yield item
-            if len(get_attribute_from_path(response, pagination.get("results_path"))) < pagination["limit_value"]:
+            if "cursor_param" in pagination:
+                if len(results) == 0:
+                    break
+            elif len(results) < pagination["limit_value"]:
                 break
 
             params = self._update_paginated_params(pagination, response)
@@ -659,9 +663,13 @@ class AsyncApiClient(ApiClient):
                 host=host,
                 collection_formats=params["collection_format"],
             )
-            for item in get_attribute_from_path(response, pagination.get("results_path")):
+            results = get_attribute_from_path(response, pagination.get("results_path"))
+            for item in results:
                 yield item
-            if len(get_attribute_from_path(response, pagination.get("results_path"))) < pagination["limit_value"]:
+            if "cursor_param" in pagination:
+                if len(results) == 0:
+                    break
+            elif len(results) < pagination["limit_value"]:
                 break
 
             params = self._update_paginated_params(pagination, response)


### PR DESCRIPTION
### What does this PR do?

Mirrors [DataDog/datadog-api-client-go#3769](https://github.com/DataDog/datadog-api-client-go/pull/3769) for the Python client. When an endpoint uses cursor-based pagination, the loop now keeps requesting pages until the server returns an empty result set, instead of stopping at the first page smaller than the requested limit. Behavior for offset/page-based pagination is unchanged.

The change is applied in both the Jinja template (`api_client.j2`) and the generated runtime helper (`api_client.py`), in both the sync and async `call_api_paginated` implementations. Pagination test cassettes already include the trailing empty-page response (regenerated previously in commit 1588b583a), so no cassette work was needed.

### Additional Notes

The break condition now branches on whether the pagination dict carries `cursor_param`: cursor pagination breaks on `len(results) == 0`, others keep the existing `len(results) < limit_value` check.

### Review checklist

Please check relevant items below:

- [x] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.
- [x] This PR does not rely on API client schema changes.
  - [x] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.