### PR TITLE
Escape backslashes in generated docstrings

### DIFF
--- a/.generator/src/generator/formatter.py
+++ b/.generator/src/generator/formatter.py
@@ -168,12 +168,12 @@ class CustomRenderer(m2r2.RestRenderer):
 def docstring(text):
     if not text:
         return text
-    return (
+    converted = (
         m2r2.convert((text or "").replace("\\n", "\\\\n"), renderer=CustomRenderer())[1:-1]
         .replace("\\ ", " ")
-        .replace("\\`", "\\\\`")
         .replace("\n\n\n", "\n\n")
     )
+    return converted.replace("\\", "\\\\")
 
 
 def _merge_imports(a, b):

--- a/.generator/tests/test_formatter.py
+++ b/.generator/tests/test_formatter.py
@@ -1,6 +1,11 @@
 import pytest
 from collections import defaultdict
-from generator.formatter import _is_valid_identifier, format_data_with_schema
+from generator.formatter import _is_valid_identifier, docstring, format_data_with_schema
+
+
+class TestDocstring:
+    def test_escapes_backslashes_for_python_string_literals(self):
+        assert "``\\\\s``" in docstring(r"regex pattern like ``\s`` for spaces")
 
 
 class TestIsValidIdentifier:

--- a/src/datadog_api_client/v1/api/logs_pipelines_api.py
+++ b/src/datadog_api_client/v1/api/logs_pipelines_api.py
@@ -35,7 +35,7 @@ class LogsPipelinesApi:
     returned data to be configured before using in a request.**
     For example, if you are using the data returned from a
     request for another request body, and have a parsing rule
-    that uses a regex pattern like ``\s`` for spaces, you will
+    that uses a regex pattern like ``\\s`` for spaces, you will
     need to configure all escaped spaces as ``%{space}`` to use
     in the body data.
     """


### PR DESCRIPTION
### What does this PR do?

Fixes #3535.

Generated API docstrings can include literal backslashes from OpenAPI descriptions. When those backslashes are written directly into Python triple-quoted docstrings, Python 3.13+ can emit `SyntaxWarning` for invalid escape sequences such as `\s`.

This updates the generator docstring formatter so rendered backslashes are escaped for Python string literals, adds a formatter regression for a regex-style `\s` example, and updates the currently affected generated `LogsPipelinesApi` docstring.

### Additional Notes

Not run locally.

### Review checklist

Please check relevant items below:

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [x] This PR does not rely on API client schema changes.
  - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.