### PR TITLE
Pin reusable workflow actions to full commit SHAs

### DIFF
--- a/.github/workflows/reusable-examples.yml
+++ b/.github/workflows/reusable-examples.yml
@@ -23,12 +23,12 @@ jobs:
   examples:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: DataDog/datadog-api-client-python
           ref: ${{ inputs.target-branch || github.ref }}
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: ${{ inputs.python-version }}
           cache: "pip"

--- a/.github/workflows/reusable-integration-test.yml
+++ b/.github/workflows/reusable-integration-test.yml
@@ -89,20 +89,20 @@ jobs:
           scope: DataDog/datadog-api-spec
           policy: datadog-api-client-python.reusable-integration-test.post-status
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: DataDog/datadog-api-client-python
           ref: ${{ inputs.target-branch || github.ref }}
       - name: Post pending status check
         if: github.event_name == 'pull_request' && contains(github.event.pull_request.head.ref, 'datadog-api-spec/generated/') && (inputs.enable-status-reporting || github.event_name != 'workflow_call')
-        uses: DataDog/github-actions/post-status-check@v2
+        uses: DataDog/github-actions/post-status-check@65b4875f33ad773d7ba4b005a2cb5f35020295f3 # v2.3.0
         with:
           github-token: ${{ steps.get_token.outputs.token }}
           repo: ${{ inputs.target-repo || 'datadog-api-spec' }}
           status: pending
           context: ${{ inputs.status-context || 'integration' }}
       - name: Set up Python 3.12
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.12"
           cache: "pip"
@@ -129,7 +129,7 @@ jobs:
           DD_TRACE_PROPAGATION_STYLE_INJECT: "datadog"
       - name: Post failure status check
         if: failure() && github.event_name == 'pull_request' && contains(github.event.pull_request.head.ref, 'datadog-api-spec/generated/') && (inputs.enable-status-reporting || github.event_name != 'workflow_call')
-        uses: DataDog/github-actions/post-status-check@v2
+        uses: DataDog/github-actions/post-status-check@65b4875f33ad773d7ba4b005a2cb5f35020295f3 # v2.3.0
         with:
           github-token: ${{ steps.get_token.outputs.token }}
           repo: ${{ inputs.target-repo || 'datadog-api-spec' }}
@@ -137,7 +137,7 @@ jobs:
           context: ${{ inputs.status-context || 'integration' }}
       - name: Post success status check
         if: "!failure() && github.event_name == 'pull_request' && contains(github.event.pull_request.head.ref, 'datadog-api-spec/generated/') && (inputs.enable-status-reporting || github.event_name != 'workflow_call')"
-        uses: DataDog/github-actions/post-status-check@v2
+        uses: DataDog/github-actions/post-status-check@65b4875f33ad773d7ba4b005a2cb5f35020295f3 # v2.3.0
         with:
           github-token: ${{ steps.get_token.outputs.token }}
           repo: ${{ inputs.target-repo || 'datadog-api-spec' }}

--- a/.github/workflows/reusable-pre-commit.yml
+++ b/.github/workflows/reusable-pre-commit.yml
@@ -32,20 +32,20 @@ jobs:
         with:
           scope: DataDog/datadog-api-client-python
           policy: self.github.pre-commit.pull-request
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           repository: DataDog/datadog-api-client-python
           ref: ${{ inputs.target-branch || github.event.pull_request.head.sha || github.ref }}
           token: ${{ inputs.enable-commit-changes && steps.octo-sts.outputs.token || github.token }}
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '3.11'
       - name: Install pre-commit
         run: python -m pip install pre-commit
       - name: set PY
         run: echo "PY=$(python -c 'import platform;print(platform.python_version())')" >> $GITHUB_ENV
-      - uses: actions/cache@v3
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/reusable-python-test.yml
+++ b/.github/workflows/reusable-python-test.yml
@@ -34,12 +34,12 @@ jobs:
         exclude: ${{ fromJSON(inputs.matrix-exclude) }}
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: DataDog/datadog-api-client-python
           ref: ${{ inputs.target-branch || github.ref }}
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
           scope: DataDog/datadog-api-spec
           policy: datadog-api-client-python.github.post-status-check.pull-request
       - name: Post status check
-        uses: DataDog/github-actions/post-status-check@v2
+        uses: DataDog/github-actions/post-status-check@65b4875f33ad773d7ba4b005a2cb5f35020295f3 # v2.3.0
         with:
           github-token: ${{ steps.octo-sts.outputs.token }}
           repo: datadog-api-spec


### PR DESCRIPTION
### What does this PR do?
The datadog-api-spec repo enforces a policy requiring all GitHub Actions to be pinned to full commit SHAs — tag references like @v3 or @v4 are rejected at job setup time, causing all test jobs to fail. This updates all reusable workflow files to pin every action to its full commit SHA. Triggered by failures seen in https://github.com/DataDog/datadog-api-spec/actions/runs/26498375372.

### Additional Notes
(none)

### Review checklist
- [ ] This PR includes all newly recorded cassettes for any modified tests.
- [x] This PR does not rely on API client schema changes.
  - [x] The CI should be fully passing.