### PR TITLE
[Fixed] Preserve integer precision in additionalProperties past 2^53

### DIFF
--- a/.generator/src/generator/templates/model_utils.j2
+++ b/.generator/src/generator/templates/model_utils.j2
@@ -1348,6 +1348,13 @@ def validate_and_convert_types(
         valid_classes_coercible = remove_uncoercible(
             valid_classes, input_value, spec_property_naming, must_convert=False
         )
+        # Preserve integer precision past 2^53: skip the (int, float) upconversion
+        # when `int` is already a valid target. Without this guard, the loop below
+        # would call `float(big_int)` for additionalProperties (whose default
+        # `additional_properties_type` contains both float and int) and silently
+        # round any integer above 2^53 to the nearest float64 representation.
+        if type(input_value) is int and int in valid_classes and float in valid_classes_coercible:
+            valid_classes_coercible = [c for c in valid_classes_coercible if c is not float]
         if valid_classes_coercible:
             return attempt_convert_item(
                 input_value,

--- a/src/datadog_api_client/model_utils.py
+++ b/src/datadog_api_client/model_utils.py
@@ -1364,6 +1364,13 @@ def validate_and_convert_types(
         valid_classes_coercible = remove_uncoercible(
             valid_classes, input_value, spec_property_naming, must_convert=False
         )
+        # Preserve integer precision past 2^53: skip the (int, float) upconversion
+        # when `int` is already a valid target. Without this guard, the loop below
+        # would call `float(big_int)` for additionalProperties (whose default
+        # `additional_properties_type` contains both float and int) and silently
+        # round any integer above 2^53 to the nearest float64 representation.
+        if type(input_value) is int and int in valid_classes and float in valid_classes_coercible:
+            valid_classes_coercible = [c for c in valid_classes_coercible if c is not float]
         if valid_classes_coercible:
             return attempt_convert_item(
                 input_value,

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -308,3 +308,36 @@ def test_get_api_test():
     path_to_item = ["received_data", "config", "steps"]
     converted_value = validate_and_convert_types(value, required_types_mixed, path_to_item, True, True, Configuration())
     assert isinstance(converted_value[0], UnparsedObject)
+
+
+def test_additional_properties_preserve_integer_precision():
+    """JSON integers above 2^53 must survive deserialization into a model's
+    additionalProperties without being silently rounded to float64."""
+    from datadog_api_client.v1.model.usage_summary_response import UsageSummaryResponse
+
+    # 2^53 + 1 — the smallest integer not exactly representable in float64.
+    edge = 9007199254740993
+    # A real byte-count value seen in /api/v1/usage/summary at large orgs.
+    realistic = 56355942906113522
+
+    body = json.dumps({"some_unknown_field": edge, "another_unknown_field": realistic})
+    config = Configuration()
+    deserialized = validate_and_convert_types(
+        json.loads(body), (UsageSummaryResponse,), ["received_data"], True, True, config
+    )
+
+    v_edge = deserialized["some_unknown_field"]
+    v_real = deserialized["another_unknown_field"]
+    assert type(v_edge) is int and v_edge == edge, (
+        f"expected int {edge}, got {type(v_edge).__name__} {v_edge!r}"
+    )
+    assert type(v_real) is int and v_real == realistic, (
+        f"expected int {realistic}, got {type(v_real).__name__} {v_real!r}"
+    )
+
+
+def test_schema_declared_float_still_upconverts_int_input():
+    """Regression guard: when the schema explicitly declares a field as float,
+    an integer JSON value must still upconvert to float."""
+    converted = validate_and_convert_types(3, (float,), ["received_data"], True, True, Configuration())
+    assert type(converted) is float and converted == 3.0

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -328,12 +328,10 @@ def test_additional_properties_preserve_integer_precision():
 
     v_edge = deserialized["some_unknown_field"]
     v_real = deserialized["another_unknown_field"]
-    assert type(v_edge) is int and v_edge == edge, (
-        f"expected int {edge}, got {type(v_edge).__name__} {v_edge!r}"
-    )
-    assert type(v_real) is int and v_real == realistic, (
-        f"expected int {realistic}, got {type(v_real).__name__} {v_real!r}"
-    )
+    assert type(v_edge) is int and v_edge == edge, f"expected int {edge}, got {type(v_edge).__name__} {v_edge!r}"
+    assert (
+        type(v_real) is int and v_real == realistic
+    ), f"expected int {realistic}, got {type(v_real).__name__} {v_real!r}"
 
 
 def test_schema_declared_float_still_upconverts_int_input():


### PR DESCRIPTION
Fixes #3649.

### What does this PR do?

Avoids lossy `int → float` upconversion in `validate_and_convert_types` when both `int` and `float` are valid target types — most commonly on `additionalProperties`, whose default `additional_properties_type` contains the full primitive set including both `float` and `int`. For integer JSON literals above 2^53, the existing code calls `float(big_int)` and silently rounds to the nearest `float64`, losing the low bits.

### Motivation

The Python SDK currently rounds integer values past 2^53 when they arrive on an `additionalProperties` map. Typed schema fields (`openapi_types = (int,)`) are unaffected because they have no `float` candidate to compete with.

In production this surfaces today for byte-count aggregates on `/api/v1/usage/summary` at large orgs (e.g. `analyzed_logs_bytes_agg_sum=56355942906113522` arrives at the caller as `5.635594290611352e+16`, rounded to `56355942906113520`). The problem will broaden as more fields move from typed accessors into the `additionalProperties` bag.

### Describe how you validated your changes

- `pytest tests/test_deserialization.py` — 10 tests pass (8 existing + 2 new).
- `pytest tests/test_serialization.py` — 2 tests pass.
- Manual repro before / after on the reproducer from #3649:
  - Before: `type=float value=9007199254740992.0` (rounded down by 1)
  - After: `type=int value=9007199254740993` (preserved)

### Behavioral contract change

Values in `additional_properties` may now be Python `int` where they were previously Python `float` — specifically, any integer JSON literal that was previously stored as float is now stored as int.

- Callers comparing values via `==` are unaffected (`5 == 5.0`).
- Callers using `isinstance(val, float)` to detect type may need `isinstance(val, (int, float))`.
- The legitimate `(int → float)` upconversion when the schema declares `float`-only (e.g. JSON `3` for a `float` field) goes through a different code path (`must_convert=True`) and is untouched.
- Typed-field accessors are unaffected.

### Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This PR's title is prefixed with `[Fixed]` per the changelog convention.
- [x] Tests for the changes have been added
- [x] All tests passed.

### See also

Same root issue + analogous fix in the Go client: DataDog/datadog-api-client-go#4091 → DataDog/datadog-api-client-go#4095.
