### PR TITLE
[Fixed] Handle unresolved oneOf instances during model serialization

### DIFF
--- a/.generator/src/generator/templates/model_utils.j2
+++ b/.generator/src/generator/templates/model_utils.j2
@@ -565,6 +565,8 @@ class ModelComposed(OpenApiModel):
 
     def get_oneof_instance(self):
         """Returns the oneOf instance"""
+        if not self._composed_instances:
+            return self
         return self._composed_instances[0]
 
     def __eq__(self, other):
@@ -1481,7 +1483,7 @@ def model_to_dict(model_instance, serialize=True):
 
     model_instances = [model_instance]
     model = model_instance
-    while model._composed_schemas:
+    while model._composed_schemas and model._composed_instances:
         model_instances.extend(model._composed_instances)
         model = model.get_oneof_instance()
 

--- a/src/datadog_api_client/model_utils.py
+++ b/src/datadog_api_client/model_utils.py
@@ -578,6 +578,8 @@ class ModelComposed(OpenApiModel):
 
     def get_oneof_instance(self):
         """Returns the oneOf instance"""
+        if not self._composed_instances:
+            return self
         return self._composed_instances[0]
 
     def __eq__(self, other):
@@ -1497,7 +1499,7 @@ def model_to_dict(model_instance, serialize=True):
 
     model_instances = [model_instance]
     model = model_instance
-    while model._composed_schemas:
+    while model._composed_schemas and model._composed_instances:
         model_instances.extend(model._composed_instances)
         model = model.get_oneof_instance()
 

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -12,6 +12,7 @@ from datadog_api_client.v2.model.downtime_response import DowntimeResponse
 from datadog_api_client.v2.model.logs_aggregate_response import LogsAggregateResponse
 from datadog_api_client.v2.model.logs_archive import LogsArchive
 from datadog_api_client.v2.model.logs_archive_destination import LogsArchiveDestination
+from datadog_api_client.v1.model.dashboard import Dashboard
 from datadog_api_client.v2.model.user_response import UserResponse
 
 
@@ -332,6 +333,55 @@ def test_additional_properties_preserve_integer_precision():
     assert (
         type(v_real) is int and v_real == realistic
     ), f"expected int {realistic}, got {type(v_real).__name__} {v_real!r}"
+
+
+def test_empty_group_by_list_does_not_raise_on_serialization():
+    """Regression guard: a query_value widget with group_by: [] must not raise
+    IndexError when the response is printed or serialized via to_dict().
+
+    The oneOf matcher for FormulaAndFunctionEventQueryGroupByConfig cannot
+    resolve an empty list to a variant, leaving _composed_instances empty.
+    model_to_dict() and get_oneof_instance() must handle this gracefully."""
+    body = """{
+        "id": "abc-def-ghi",
+        "title": "Test Dashboard",
+        "layout_type": "ordered",
+        "widgets": [
+            {
+                "id": 1234567890,
+                "definition": {
+                    "type": "query_value",
+                    "requests": [
+                        {
+                            "response_format": "scalar",
+                            "queries": [
+                                {
+                                    "data_source": "logs",
+                                    "name": "query1",
+                                    "search": {"query": ""},
+                                    "indexes": ["*"],
+                                    "compute": {"aggregation": "count"},
+                                    "group_by": [],
+                                    "storage": "hot"
+                                }
+                            ]
+                        }
+                    ],
+                    "autoscale": true,
+                    "precision": 2
+                },
+                "layout": {"x": 0, "y": 0, "width": 2, "height": 2}
+            }
+        ]
+    }"""
+    config = Configuration()
+    deserialized_data = validate_and_convert_types(
+        json.loads(body), (Dashboard,), ["received_data"], True, True, config
+    )
+    assert isinstance(deserialized_data, Dashboard)
+    result = model_to_dict(deserialized_data)
+    assert result["title"] == "Test Dashboard"
+    assert str(deserialized_data) != ""
 
 
 def test_schema_declared_float_still_upconverts_int_input():


### PR DESCRIPTION
Fixes #https://github.com/DataDog/datadog-api-client-python/issues/3656.

### What does this PR do?

Updates the `model_utils.j2` template to guard `model_to_dict()` against entering the `_composed_schemas` traversal loop when `_composed_instances` is empty, and makes `get_oneof_instance()` fall back to `self` instead of raising `IndexError` when no `oneOf` variant was resolved during deserialization. The fix is applied to the template so the generated `src/datadog_api_client/model_utils.py` is updated accordingly.

### Motivation

The Python SDK raises `IndexError: list index out of range` when calling `print(response)` — or any operation that triggers `to_dict()` — on a dashboard response containing a `query_value` widget with `"group_by": []`.

The `group_by` field is typed as `FormulaAndFunctionEventQueryGroupByConfig`, a `ModelComposed` class with a `oneOf` of two variants: a list of group-by objects and a fields object. When the API returns an empty list `[]`, the `oneOf` matcher cannot determine which variant it belongs to — there are no items to validate types against — so `_composed_instances` is left empty.

`model_to_dict()` then enters the `while model._composed_schemas` loop unconditionally and crashes at `get_oneof_instance()`, which accesses `self._composed_instances[0]` on an empty list.

### Describe how you validated your changes

- Fixed `.generator/src/generator/templates/model_utils.j2` — the source template for the generated `model_utils.py`.
- Added a regression test `test_empty_group_by_list_does_not_raise_on_serialization` in `tests/test_deserialization.py` that deserializes a dashboard with `group_by: []` and asserts that `to_dict()` and `str()` complete without error.
- `pytest tests/test_deserialization.py` — all tests pass.
- Manual repro before / after:
  - Before: `IndexError: list index out of range` on `print(response)` for any dashboard with a logs `query_value` widget using `group_by: []`
  - After: response serializes and prints correctly.

### Behavioral contract change

No behavioral change for dashboards where `oneOf` resolution succeeds. For unresolved `oneOf` fields (empty list case), `to_dict()` now falls through to the raw `_data_store` contents instead of crashing.

### Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This PR's title is prefixed with `[Fixed]` per the changelog convention.
- [x] Tests for the changes have been added
- [x] All tests passed.
