### PR TITLE
[AGV-1595] Add is_iac support to send X-Datadog-Managed-By header

### DIFF
--- a/.generator/src/generator/templates/api_client.j2
+++ b/.generator/src/generator/templates/api_client.j2
@@ -52,6 +52,8 @@ class ApiClient:
         self.default_headers = {}
         if self.configuration.compress:
             self.default_headers["Accept-Encoding"] = "gzip"
+        if self.configuration.is_iac:
+            self.default_headers["X-Datadog-Managed-By"] = "iac"
         # Set default User-Agent.
         self.user_agent = user_agent()
         

--- a/.generator/src/generator/templates/configuration.j2
+++ b/.generator/src/generator/templates/configuration.j2
@@ -149,6 +149,10 @@ class Configuration:
     :type delegated_auth_provider: str
     :param delegated_auth_org_uuid: The organization UUID for delegated authentication.
     :type delegated_auth_org_uuid: str
+    :param is_iac: Set to True to indicate that requests made through this client originate from
+        infrastructure-as-code or other automation tooling. When set, the client sends the
+        ``X-Datadog-Managed-By: iac`` header on every request.
+    :type is_iac: bool
     """
 
     def __init__(
@@ -179,6 +183,7 @@ class Configuration:
         retry_policy=None,
         delegated_auth_provider=None,
         delegated_auth_org_uuid=None,
+        is_iac=False,
     ):
         """Constructor."""
         self._base_path = "https://api.datadoghq.com" if host is None else host
@@ -229,6 +234,10 @@ class Configuration:
 
         # Will translate to a Accept-Encoding header
         self.compress = compress
+
+        # Set to True to indicate that requests are made from infrastructure-as-code tooling.
+        # Will translate to a X-Datadog-Managed-By header.
+        self.is_iac = is_iac
 
         self.return_http_data_only = return_http_data_only
         self.preload_content = preload_content

--- a/src/datadog_api_client/api_client.py
+++ b/src/datadog_api_client/api_client.py
@@ -54,6 +54,8 @@ class ApiClient:
         self.default_headers = {}
         if self.configuration.compress:
             self.default_headers["Accept-Encoding"] = "gzip"
+        if self.configuration.is_iac:
+            self.default_headers["X-Datadog-Managed-By"] = "iac"
         # Set default User-Agent.
         self.user_agent = user_agent()
 

--- a/src/datadog_api_client/configuration.py
+++ b/src/datadog_api_client/configuration.py
@@ -150,6 +150,10 @@ class Configuration:
     :type delegated_auth_provider: str
     :param delegated_auth_org_uuid: The organization UUID for delegated authentication.
     :type delegated_auth_org_uuid: str
+    :param is_iac: Set to True to indicate that requests made through this client originate from
+        infrastructure-as-code or other automation tooling. When set, the client sends the
+        ``X-Datadog-Managed-By: iac`` header on every request.
+    :type is_iac: bool
     """
 
     def __init__(
@@ -180,6 +184,7 @@ class Configuration:
         retry_policy=None,
         delegated_auth_provider=None,
         delegated_auth_org_uuid=None,
+        is_iac=False,
     ):
         """Constructor."""
         self._base_path = "https://api.datadoghq.com" if host is None else host
@@ -230,6 +235,10 @@ class Configuration:
 
         # Will translate to a Accept-Encoding header
         self.compress = compress
+
+        # Set to True to indicate that requests are made from infrastructure-as-code tooling.
+        # Will translate to a X-Datadog-Managed-By header.
+        self.is_iac = is_iac
 
         self.return_http_data_only = return_http_data_only
         self.preload_content = preload_content

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -348,3 +348,21 @@ class TestClientDelegatedAuthenticationWithRealMocks:
         api_client.use_delegated_token_auth(headers3)
         assert headers3["Authorization"] == "Bearer token-2"
         assert call_count == 2  # New call made
+
+
+class TestClientIsIac:
+    """Test that the is_iac configuration flag controls the X-Datadog-Managed-By header."""
+
+    def test_is_iac_header_absent_by_default(self):
+        """Test that the header is not set when is_iac is left at its default."""
+        config = Configuration()
+        api_client = ApiClient(config)
+
+        assert "X-Datadog-Managed-By" not in api_client.default_headers
+
+    def test_is_iac_header_present_when_enabled(self):
+        """Test that the header is set when is_iac is enabled on the configuration."""
+        config = Configuration(is_iac=True)
+        api_client = ApiClient(config)
+
+        assert api_client.default_headers["X-Datadog-Managed-By"] == "iac"


### PR DESCRIPTION
## Summary
- Adds `Configuration(is_iac=False)` kwarg (appended last, no positional break), which when enabled sends the `X-Datadog-Managed-By: iac` header on all requests.
- Lets Datadog distinguish infrastructure-as-code API traffic from other client usage.
- Configured at client-creation time via `Configuration`; existing constructors are unaffected.

## Test plan
- [x] New `TestClientIsIac` class in `tests/client_test.py` covering header-off-by-default and header-set-when-enabled behavior
- [x] `pytest tests/ --ignore=tests/v1 --ignore=tests/v2`: 67 passed, 3 skipped (pre-existing, unrelated)
- [x] `mypy src`: clean
- [x] `ruff check` / `ruff format --check`: clean

___All of the API generation is moving to a new repo. This PR may never be merged, but changes are present in [openapi-transformer#389](https://github.com/DataDog/openapi-transformer/pull/389)___

🤖 Generated with [Claude Code](https://claude.com/claude-code)